### PR TITLE
fix/miniapp: nft collection stats should not be optional

### DIFF
--- a/examples/api/src/app/api/open-graph/lib/util.ts
+++ b/examples/api/src/app/api/open-graph/lib/util.ts
@@ -121,10 +121,8 @@ export async function fetchNFTMetadata({
     `https://api.opensea.io/api/v1/collection/${collectionSlug}/stats`,
     authOptions
   );
-  let collectionStats: any = {};
-  if (collectionStatsResponse.ok) {
-    collectionStats = await collectionStatsResponse.json();
-  }
+  // Collection stats should exist if the collection exists
+  const collectionStats = await collectionStatsResponse.json();
 
   const fcUser = await fetchUserData(collectionData.owner);
 
@@ -150,8 +148,8 @@ export async function fetchNFTMetadata({
       id: caip19Uri,
       name: collectionData.name,
       description: collectionData.description,
-      itemCount: collectionStats?.stats.count,
-      ownerCount: collectionStats?.stats.num_owners,
+      itemCount: collectionStats.stats.count,
+      ownerCount: collectionStats.stats.num_owners,
       imageUrl: image,
       mintUrl: mintUrl || collectionData.opensea_url,
       openSeaUrl: collectionData.opensea_url,

--- a/packages/core/src/embeds.ts
+++ b/packages/core/src/embeds.ts
@@ -29,8 +29,8 @@ export type NFTMetadata = {
     id: string;
     name: string;
     description: string;
-    itemCount?: number;
-    ownerCount?: number;
+    itemCount: number;
+    ownerCount: number;
     imageUrl: string;
     mintUrl: string;
     openSeaUrl?: string;


### PR DESCRIPTION
Addresses an unresolved issue on #12 where the NftMetadata type was incorrectly modified to have optional itemCount and ownerCount properties. If these properties are unavailable, the endpoint should explicitly fail.