### PR TITLE
fix(image-render): match image embeds based on file extension in url

### DIFF
--- a/.changeset/eight-terms-burn.md
+++ b/.changeset/eight-terms-burn.md
@@ -1,0 +1,5 @@
+---
+"@miniapps/image-render": patch
+---
+
+fix: match image embeds based on file extension in url

--- a/miniapps/image-render/src/manifest.ts
+++ b/miniapps/image-render/src/manifest.ts
@@ -13,7 +13,15 @@ const manifest: ModManifest = {
       if: {
         value: "{{embed.url}}",
         match: {
-          equals: "{{embed.metadata.image.url}}",
+          OR: [
+            { equals: "{{embed.metadata.image.url}}" },
+            { endsWith: ".png" },
+            { endsWith: ".jpg" },
+            { endsWith: ".jpeg" },
+            { endsWith: ".gif" },
+            { endsWith: ".svg" },
+            { endsWith: ".webp" },
+          ],
         },
       },
       element: view,


### PR DESCRIPTION
Updated `image-render` miniapp content entry points to be matched when the embed URL ends with common image extensions i.e. `.png`, `.jpg`, `.jpeg`, `.gif`, `.svg`, and `.webp`