### PR TITLE
fix(giphy-picker): improve giphy picker performance

### DIFF
--- a/examples/api/src/app/api/open-graph/lib/url-handlers/fallback.ts
+++ b/examples/api/src/app/api/open-graph/lib/url-handlers/fallback.ts
@@ -50,7 +50,7 @@ async function fallbackUrlHandler(url: string): Promise<UrlMetadata> {
       },
     }
   );
-  const { data, status, message, code, more } = await response.json();
+  const { data, headers, message } = await response.json();
 
   if (!response.ok) {
     throw new Error(message);
@@ -73,6 +73,7 @@ async function fallbackUrlHandler(url: string): Promise<UrlMetadata> {
           url: data.logo.url,
         }
       : undefined,
+    mimeType: headers["content-type"],
   };
 
   // Zip opengraph extension data into a single object

--- a/packages/core/src/embeds.ts
+++ b/packages/core/src/embeds.ts
@@ -3,8 +3,9 @@ import { FarcasterEmbed, isFarcasterUrlEmbed } from "@mod-protocol/farcaster";
 export function isImageEmbed(embed: Embed) {
   return (
     isFarcasterUrlEmbed(embed) &&
-    embed.metadata?.hasOwnProperty("image") &&
-    embed.url === embed.metadata?.image?.url
+    ((embed.metadata?.hasOwnProperty("image") &&
+      embed.url === embed.metadata?.image?.url) ||
+      embed.metadata?.mimeType?.startsWith("image"))
   );
 }
 
@@ -59,6 +60,7 @@ export type UrlMetadata = {
     url: string;
   };
   nft?: NFTMetadata;
+  mimeType?: string;
 };
 
 export type Embed = {

--- a/packages/core/src/web-handlers.ts
+++ b/packages/core/src/web-handlers.ts
@@ -30,7 +30,11 @@ export const fetchUrlMetadata = (api_url: string) => {
 export const handleAddEmbed =
   (addEmbed: (embed: Embed) => void) =>
   (init: AddEmbedActionResolverInit, events: AddEmbedActionResolverEvents) => {
-    addEmbed({ url: init.url, status: "loading" });
+    addEmbed({
+      url: init.url,
+      status: "loading",
+      metadata: { mimeType: init.mimeType },
+    });
     events.onSuccess();
   };
 

--- a/packages/react-editor/src/use-editor.tsx
+++ b/packages/react-editor/src/use-editor.tsx
@@ -106,6 +106,7 @@ export function useEditor({
           // Embed not loaded yet
           if (isFarcasterUrlEmbed(newEmbed) && newEmbed.status !== "loaded") {
             // Fetch type (url or image) and OG data async
+
             fetchUrlMetadata(newEmbed.url)
               .then((urlMetadata: UrlMetadata) => {
                 updateEmbedsWithLoadedData(newEmbed.url, urlMetadata);
@@ -114,7 +115,14 @@ export function useEditor({
                 onError(err);
               });
 
-            return [...embedsState, { url: newEmbed.url, status: "loading" }];
+            return [
+              ...embedsState,
+              {
+                url: newEmbed.url,
+                metadata: newEmbed.metadata,
+                status: "loading",
+              },
+            ];
           }
 
           // Embed already loaded

--- a/packages/react-ui-shadcn/src/lib/embeds.tsx
+++ b/packages/react-ui-shadcn/src/lib/embeds.tsx
@@ -1,17 +1,14 @@
-import { Button } from "components/ui/button";
-import { Skeleton } from "components/ui/skeleton";
-import {
-  isFarcasterCastIdEmbed,
-  isFarcasterUrlEmbed,
-} from "@mod-protocol/farcaster";
-import { Cross1Icon } from "@radix-ui/react-icons";
-import { VideoRenderer } from "../renderers/video";
 import {
   Embed,
   hasFullSizedImage,
   isImageEmbed,
   isVideoEmbed,
 } from "@mod-protocol/core";
+import { isFarcasterUrlEmbed } from "@mod-protocol/farcaster";
+import { Cross1Icon } from "@radix-ui/react-icons";
+import { Button } from "components/ui/button";
+import { Skeleton } from "components/ui/skeleton";
+import { VideoRenderer } from "../renderers/video";
 
 export const EmbedsEditor = (props: {
   embeds: Embed[];
@@ -31,67 +28,61 @@ export const EmbedsEditor = (props: {
           >
             <Cross1Icon />
           </Button>
-          {embed.status === "loading" ? (
-            <div>
-              <Skeleton className="h-[100px] w-full items-center flex justify-center">
-                loading
-              </Skeleton>
+          {isFarcasterUrlEmbed(embed) && isImageEmbed(embed) ? (
+            <div className="border rounded mt-2" key={i}>
+              <img
+                src={embed.url}
+                alt={embed.metadata?.alt}
+                className="rounded"
+                style={{ width: "100%" }}
+                width={300}
+                height={100}
+              />
             </div>
-          ) : isFarcasterCastIdEmbed(embed) ? (
-            <></>
-          ) : isVideoEmbed(embed) ? (
+          ) : isFarcasterUrlEmbed(embed) && isVideoEmbed(embed) ? (
             <VideoRenderer videoSrc={embed.url} />
-          ) : isFarcasterUrlEmbed(embed) ? (
-            isImageEmbed(embed) ? (
-              <div className="border rounded mt-2" key={i}>
+          ) : embed.status === "loading" ? (
+            <Skeleton className="h-[100px] w-full items-center flex justify-center">
+              Loading...
+            </Skeleton>
+          ) : hasFullSizedImage(embed) ? (
+            <div className="border rounded mt-2" key={i}>
+              <div style={{ maxHeight: "200px", overflow: "hidden" }}>
                 <img
-                  src={embed.url}
-                  alt={embed.metadata?.alt}
-                  className="rounded"
+                  src={embed.metadata?.image?.url}
+                  alt={embed.metadata?.title}
+                  className="rounded-t"
                   style={{ width: "100%" }}
                   width={300}
                   height={100}
                 />
               </div>
-            ) : hasFullSizedImage(embed) ? (
-              <div className="border rounded mt-2" key={i}>
-                <div style={{ maxHeight: "200px", overflow: "hidden" }}>
+              <div className="p-2">
+                <div className="font-bold">{embed.metadata?.title}</div>
+                <div className="text-slate-600">
+                  {embed.metadata?.publisher}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="border rounded mt-2" key={i}>
+              <div className="p-2">
+                <div className="flex flex-row">
                   <img
-                    src={embed.metadata?.image?.url}
+                    src={embed.metadata?.logo?.url}
                     alt={embed.metadata?.title}
-                    className="rounded-t"
-                    style={{ width: "100%" }}
-                    width={300}
-                    height={100}
+                    className="w-6 rounded mr-1"
+                    width={6}
+                    height={6}
                   />
-                </div>
-                <div className="p-2">
                   <div className="font-bold">{embed.metadata?.title}</div>
-                  <div className="text-slate-600">
-                    {embed.metadata?.publisher}
-                  </div>
+                </div>
+                <div className="text-slate-600">
+                  {embed.metadata?.publisher}
                 </div>
               </div>
-            ) : (
-              <div className="border rounded mt-2" key={i}>
-                <div className="p-2">
-                  <div className="flex flex-row">
-                    <img
-                      src={embed.metadata?.logo?.url}
-                      alt={embed.metadata?.title}
-                      className="w-6 rounded mr-1"
-                      width={6}
-                      height={6}
-                    />
-                    <div className="font-bold">{embed.metadata?.title}</div>
-                  </div>
-                  <div className="text-slate-600">
-                    {embed.metadata?.publisher}
-                  </div>
-                </div>
-              </div>
-            )
-          ) : null}
+            </div>
+          )}
         </div>
       ))}
     </>


### PR DESCRIPTION
Improve performance of giphy picker by 
- Loading embed previews directly from URL (skipping opengraph API) if the mimetype is present

Fixes #28 