### PR TITLE
chore(open-graph/nft): normalize NFT metadata types

### DIFF
--- a/.changeset/fuzzy-pets-lie.md
+++ b/.changeset/fuzzy-pets-lie.md
@@ -1,0 +1,7 @@
+---
+"@miniapps/nft-minter": patch
+"@mod-protocol/core": patch
+"api": patch
+---
+
+chore: normalize NFT metadata type

--- a/examples/nextjs-shadcn/src/app/dummy-casts.ts
+++ b/examples/nextjs-shadcn/src/app/dummy-casts.ts
@@ -73,13 +73,12 @@ export const dummyCastData: Array<{
             url: "https://ipfs.decentralized-content.com/ipfs/bafybeicto6doldfjy7nrqxn7jiduw47xs7cmzppjd6mm3mrao4z46asiwq",
           },
           nft: {
-            collectionName: "Farcaster v3",
-            contractAddress: "0xbfdb5d8d1856b8617f1881fd718580256fa8cf35",
-            creatorAddress: "0xd7029bdea1c17493893aafe29aad69ef892b8ff2",
             mediaUrl:
-              "https://zora.co/api/thumbnail/https%3A%2F%2Fipfs.decentralized-content.com%2Fipfs%2Fbafybeicto6doldfjy7nrqxn7jiduw47xs7cmzppjd6mm3mrao4z46asiwq",
-            chain: "base",
+              "https://remote-image.decentralized-content.com/image?url=https%3A%2F%2Fipfs.decentralized-content.com%2Fipfs%2Fbafybeicto6doldfjy7nrqxn7jiduw47xs7cmzppjd6mm3mrao4z46asiwq&w=1920&q=75",
             collection: {
+              contractAddress: "0xbfdb5d8d1856b8617f1881fd718580256fa8cf35",
+              creatorAddress: "0xd7029bdea1c17493893aafe29aad69ef892b8ff2",
+              chain: "base",
               id: "farcaster-v3-1",
               name: "Farcaster v3",
               description: "A new chapter for Farcaster",
@@ -90,13 +89,13 @@ export const dummyCastData: Array<{
               mintUrl:
                 "https://zora.co/collect/base:0xbfdb5d8d1856b8617f1881fd718580256fa8cf35",
               openSeaUrl: "https://opensea.io/collection/farcaster-v3-1",
-            },
-            creator: {
-              fid: 3,
-              username: "dwr.eth",
-              displayName: "Dan Romero",
-              pfp: {
-                url: "https://res.cloudinary.com/merkle-manufactory/image/fetch/c_fill,f_png,w_256/https://lh3.googleusercontent.com/MyUBL0xHzMeBu7DXQAqv0bM9y6s4i4qjnhcXz5fxZKS3gwWgtamxxmxzCJX7m2cuYeGalyseCA2Y6OBKDMR06TWg2uwknnhdkDA1AA",
+              creator: {
+                fid: 3,
+                username: "dwr.eth",
+                displayName: "Dan Romero",
+                pfp: {
+                  url: "https://res.cloudinary.com/merkle-manufactory/image/fetch/c_fill,f_png,w_256/https://lh3.googleusercontent.com/MyUBL0xHzMeBu7DXQAqv0bM9y6s4i4qjnhcXz5fxZKS3gwWgtamxxmxzCJX7m2cuYeGalyseCA2Y6OBKDMR06TWg2uwknnhdkDA1AA",
+                },
               },
             },
           },

--- a/miniapps/nft-minter/src/manifest.ts
+++ b/miniapps/nft-minter/src/manifest.ts
@@ -11,7 +11,7 @@ const manifest: ModManifest = {
   contentEntrypoints: [
     {
       if: {
-        value: "{{embed.metadata.nft.collectionName}}",
+        value: "{{embed.metadata.nft.collection.name}}",
         match: {
           NOT: {
             equals: "",

--- a/miniapps/nft-minter/src/view.ts
+++ b/miniapps/nft-minter/src/view.ts
@@ -5,7 +5,7 @@ const view: ModElement[] = [
     type: "card",
     imageSrc: "{{embed.metadata.nft.mediaUrl}}",
     aspectRatio: 16 / 11,
-    topLeftBadge: "@{{embed.metadata.nft.creator.username}}",
+    topLeftBadge: "@{{embed.metadata.nft.collection.creator.username}}",
     onclick: {
       type: "OPENLINK",
       url: "{{embed.metadata.nft.collection.openSeaUrl}}",
@@ -17,7 +17,7 @@ const view: ModElement[] = [
         elements: [
           {
             type: "avatar",
-            src: "{{api}}/nft-chain-logo?chain={{embed.metadata.nft.chain}}",
+            src: "{{api}}/nft-chain-logo?chain={{embed.metadata.nft.collection.chain}}",
           },
           {
             type: "text",

--- a/packages/core/src/embeds.ts
+++ b/packages/core/src/embeds.ts
@@ -20,29 +20,32 @@ export function hasFullSizedImage(embed: Embed) {
   );
 }
 
+export type FarcasterUser = {
+  fid: number;
+  username: string;
+  displayName: string;
+  pfp: {
+    url: string;
+  };
+};
+
 export type NFTMetadata = {
-  collectionName: string;
-  contractAddress: string;
-  creatorAddress: string;
-  mediaUrl: string;
-  chain: string;
+  owner?: FarcasterUser;
+  tokenId?: string;
+  mediaUrl?: string;
   collection: {
     id: string;
     name: string;
-    description: string;
+    chain: string;
+    contractAddress: string;
+    creatorAddress: string;
     itemCount: number;
     ownerCount: number;
-    imageUrl: string;
     mintUrl: string;
+    description?: string;
+    imageUrl?: string;
     openSeaUrl?: string;
-  };
-  creator?: {
-    fid: number;
-    username: string;
-    displayName: string;
-    pfp: {
-      url: string;
-    };
+    creator?: FarcasterUser;
   };
 };
 


### PR DESCRIPTION
Normalizes the `NFTMetadata` type, which is used in `open-graph` API endpoint as the format to provide the NFT metadata in. The `nft-minter` miniapp and embed metadata indexer app depend on this endpoint.