### PR TITLE
fix(open-graph/nft): handle eth mainnet zora urls

### DIFF
--- a/examples/api/src/app/api/open-graph/lib/url-handlers/zora.ts
+++ b/examples/api/src/app/api/open-graph/lib/url-handlers/zora.ts
@@ -5,7 +5,9 @@ import { fetchNFTMetadata, toUrlMetadata } from "../util";
 async function handleZoraCollectUrl(url: string): Promise<UrlMetadata | null> {
   const [, , , , chainAndContractAddress] = url.split("/");
 
-  const [chain, contractAddress] = chainAndContractAddress.split(":");
+  let [chain, contractAddress] = chainAndContractAddress.split(":");
+
+  if (chain === "eth") chain = "ethereum";
 
   const nftMetadata = await fetchNFTMetadata({
     contractAddress,


### PR DESCRIPTION
Chain name was extracted as `eth` and should be `ethereum`