### PR TITLE
fix: dummy image url

### DIFF
--- a/examples/nextjs-shadcn/src/app/dummy-casts.ts
+++ b/examples/nextjs-shadcn/src/app/dummy-casts.ts
@@ -67,7 +67,7 @@ export const dummyCastData: Array<{
           description: "A new chapter for Farcaster",
           publisher: "zora.co",
           image: {
-            url: "https://zora.co/api/thumbnail/https%3A%2F%2Fipfs.decentralized-content.com%2Fipfs%2Fbafybeicto6doldfjy7nrqxn7jiduw47xs7cmzppjd6mm3mrao4z46asiwq",
+            url: "https://ipfs.decentralized-content.com/ipfs/bafybeicto6doldfjy7nrqxn7jiduw47xs7cmzppjd6mm3mrao4z46asiwq",
           },
           logo: {
             url: "https://ipfs.decentralized-content.com/ipfs/bafybeicto6doldfjy7nrqxn7jiduw47xs7cmzppjd6mm3mrao4z46asiwq",


### PR DESCRIPTION
fixes https://linear.app/modprotocol/issue/MOD-65/nft-mini-app-image-and-ponder-image-is-404ing-on-httpsexample