### PR TITLE
fix: markup not being preserved by setting text

### DIFF
--- a/examples/nextjs-shadcn/src/app/editor-example.tsx
+++ b/examples/nextjs-shadcn/src/app/editor-example.tsx
@@ -41,7 +41,7 @@ const API_URL =
 const getResults = getFarcasterMentions(API_URL);
 const getChannels = getFarcasterChannels(API_URL);
 const getUrlMetadata = fetchUrlMetadata(API_URL);
-const onError = (err) => window.alert(err.message);
+const onError = (err) => console.error(err.message);
 const onSubmit = async ({
   text,
   embeds,

--- a/packages/farcaster/src/structure-cast.ts
+++ b/packages/farcaster/src/structure-cast.ts
@@ -14,8 +14,9 @@ export const imgRegex = /(https?:\/\/.*\.(?:png|jpg|gif|webp|jpeg))/i;
 export const videoRegex = /(https?:\/\/.*\.(?:mp4|webm|avi|mov))/i;
 
 /** https://github.com/farcasterxyz/protocol/discussions/90 **/
-const usernameRegexForSplit = /(^|\s|\.)(@[a-z0-9][a-z0-9-]{0,15}(?:\.eth)?)/gi;
-const usernameRegex = /(?:^|\s)@([a-z0-9][a-z0-9-]{0,15}(?:\.eth)?)/gi;
+export const usernameRegexForSplit =
+  /(^|\s|\.)(@[a-z0-9][a-z0-9-]{0,15}(?:\.eth)?)/gi;
+export const usernameRegex = /(?:^|\s)@([a-z0-9][a-z0-9-]{0,15}(?:\.eth)?)/gi;
 
 const newlineRegex = /(\n)/gi;
 


### PR DESCRIPTION
fixes https://linear.app/modprotocol/issue/MOD-64/chatgpt-plugin-replace-text-doesnt-linkify-usernames-and-urls