### PR TITLE
fix: dependency issue in miniapp-registry package

### DIFF
--- a/packages/miniapp-registry/package.json
+++ b/packages/miniapp-registry/package.json
@@ -9,6 +9,9 @@
     "build": "tsup src/index.ts --format cjs,esm --dts",
     "dev": "npm run build -- --watch"
   },
+  "dependencies": {
+    "@mod-protocol/core": "*"
+  },
   "devDependencies": {
     "eslint": "^7.32.0",
     "eslint-config-custom": "*",


### PR DESCRIPTION
Adds missing `@modprotocol/core` dependency to the miniapp-registry's `package.json` 