### PR TITLE
feat(indexer): return embed metadata as ordered list

### DIFF
--- a/examples/api/src/app/api/cast-embeds-metadata/types/db.d.ts
+++ b/examples/api/src/app/api/cast-embeds-metadata/types/db.d.ts
@@ -11,6 +11,8 @@ export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 export interface CastEmbedUrls {
   cast_hash: Buffer;
   id: Generated<Int8>;
+  index: number;
+  unnormalized_url: string;
   url: string;
 }
 
@@ -57,7 +59,6 @@ export interface UrlMetadata {
   alt: string | null;
   created_at: Generated<Timestamp>;
   description: string | null;
-  id: Generated<Int8>;
   image_height: number | null;
   image_url: string | null;
   image_width: number | null;

--- a/examples/metadata-indexer/src/db.ts
+++ b/examples/metadata-indexer/src/db.ts
@@ -1,6 +1,5 @@
 import {
   CamelCasePlugin,
-  ColumnType,
   FileMigrationProvider,
   Generated,
   GeneratedAlways,
@@ -63,8 +62,6 @@ export type NftCollectionRow = {
   createdAt: Generated<Date>;
   updatedAt: Generated<Date>;
   name: string;
-  // contractAddress: string;
-  // chain: string;
   description: string | null;
   creatorAddress: string;
   itemCount: number;
@@ -87,6 +84,8 @@ export type NftMetadataRow = {
 export type CastEmbedUrlRow = {
   castHash: Uint8Array;
   url: string;
+  unnormalizedUrl: string;
+  index: number;
 };
 
 export type UrlMetadataRow = {

--- a/examples/metadata-indexer/src/hubReplicator.ts
+++ b/examples/metadata-indexer/src/hubReplicator.ts
@@ -270,17 +270,21 @@ export class HubReplicator {
         const urlEmbeds = castRow.transformedEmbeds.filter((embed) =>
           Object.hasOwn(embed, "url")
         ) as { url: string }[];
-        const urls = urlEmbeds
-          .map((embed) => normalizeUrl(embed.url))
-          .filter((url) => url !== null) as string[];
+        const urls = urlEmbeds.map((embed, index) => ({
+          normalizedUrl: normalizeUrl(embed.url),
+          url: embed.url,
+          index,
+        }));
 
         await this.db
           .insertInto("castEmbedUrls")
           .values(
-            urls.map((url) => {
+            urls.map(({ url, normalizedUrl, index }) => {
               return {
                 castHash: castRow.hash,
-                url,
+                url: normalizedUrl, // Null values filtered above
+                unnormalizedUrl: url,
+                index,
               };
             })
           )
@@ -295,7 +299,9 @@ export class HubReplicator {
 
         // Add any new URLs to the indexer queue
         if (process.env["INDEX_DISABLE"] !== "true") {
-          urls.forEach((url) => this.indexerQueue.push(url));
+          urls.forEach(({ normalizedUrl }) =>
+            this.indexerQueue.push(normalizedUrl)
+          );
         }
       }
     }

--- a/examples/metadata-indexer/src/migrations/001_initial_migration.ts
+++ b/examples/metadata-indexer/src/migrations/001_initial_migration.ts
@@ -90,6 +90,12 @@ export const up = async (db: DB) => {
     .execute();
 
   await db.schema
+    .createIndex("nft_collections_id_index")
+    .on("nftCollections")
+    .column("id")
+    .execute();
+
+  await db.schema
     .createTable("nftMetadata")
     // CAIP-19 ID
     .addColumn("id", "text", (col) => col.notNull())
@@ -118,10 +124,13 @@ export const up = async (db: DB) => {
     )
     .addColumn("castHash", "bytea", (col) => col.notNull())
     .addColumn("url", "text", (col) => col.notNull())
+    .addColumn("unnormalizedUrl", "text", (col) => col.notNull())
+    .addColumn("index", "integer", (col) => col.notNull())
     .$call((qb) =>
       qb.addUniqueConstraint("castEmbedUrls_hash_url_unique", [
         "url",
         "castHash",
+        "index",
       ])
     )
     .execute();

--- a/examples/metadata-indexer/src/util/util.ts
+++ b/examples/metadata-indexer/src/util/util.ts
@@ -78,7 +78,7 @@ export function bytesToHex(
   return `0x${Buffer.from(bytes).toString("hex")}`;
 }
 
-export function normalizeUrl(url: string): string | null {
+export function normalizeUrl(url: string): string {
   try {
     const normalizedUrl = normalizeUrl_(url, {
       forceHttps: true,
@@ -93,5 +93,5 @@ export function normalizeUrl(url: string): string | null {
     }
   }
 
-  return null;
+  return url;
 }

--- a/packages/miniapp-registry/src/index.ts
+++ b/packages/miniapp-registry/src/index.ts
@@ -14,7 +14,6 @@ export const allMiniApps = [
   InfuraIPFSUpload,
   LivepeerVideo,
   GiphyPicker,
-  ChatGPTMiniText,
   VideoRender,
   NFTMinter,
   ImageRender,


### PR DESCRIPTION
- Adds two columns to the cast_embed_url table, `unnormalized_url` and `index`
- Uses the `index` column to order embeds in the API response