### PR TITLE
fix: metadata indexer build and backfill improvements

### DIFF
--- a/examples/metadata-indexer/nixpacks.toml
+++ b/examples/metadata-indexer/nixpacks.toml
@@ -1,0 +1,2 @@
+[phases.setup]
+nixPkgs = ['...', 'python3', 'gcc']

--- a/examples/metadata-indexer/src/indexerQueue.ts
+++ b/examples/metadata-indexer/src/indexerQueue.ts
@@ -2,6 +2,7 @@ import fastq, { queueAsPromised } from "fastq";
 import { DB } from "./db";
 import { Logger } from "./log";
 import humanizeDuration from "humanize-duration";
+import { shuffle } from "./util/util";
 
 export class IndexerQueue {
   private indexQueue: queueAsPromised<{ url: string }>;
@@ -44,7 +45,10 @@ export class IndexerQueue {
 
     this.log.info(`[URL Indexer] Found ${urlsToIndex.length} URLs to index`);
 
-    urlsToIndex.map((row) => this.indexQueue.push(row));
+    // Shuffle URLs to avoid overloading a single host
+    const shuffledUrlsToIndex = shuffle(urlsToIndex);
+
+    shuffledUrlsToIndex.map((row) => this.indexQueue.push(row));
     this.log.info(
       `[URL Indexer] Queued ${this.indexQueue.length()} URLs for indexing`
     );

--- a/examples/metadata-indexer/src/util/util.test.ts
+++ b/examples/metadata-indexer/src/util/util.test.ts
@@ -1,0 +1,10 @@
+import { shuffle } from "./util";
+
+describe("util", () => {
+  test("shuffle", () => {
+    const array = [1, 2, 3, 4, 5];
+    const shuffled = shuffle(array);
+    expect(shuffled).not.toEqual(array);
+    expect(shuffled.sort()).toEqual(array);
+  });
+});

--- a/examples/metadata-indexer/src/util/util.ts
+++ b/examples/metadata-indexer/src/util/util.ts
@@ -95,3 +95,25 @@ export function normalizeUrl(url: string): string {
 
   return url;
 }
+
+// Source: https://stackoverflow.com/a/2450976
+export function shuffle<T>(initial: T[]) {
+  const array = [...initial];
+  let currentIndex = array.length,
+    randomIndex;
+
+  // While there remain elements to shuffle.
+  while (currentIndex > 0) {
+    // Pick a remaining element.
+    randomIndex = Math.floor(Math.random() * currentIndex);
+    currentIndex--;
+
+    // And swap it with the current element.
+    [array[currentIndex], array[randomIndex]] = [
+      array[randomIndex]!,
+      array[currentIndex]!,
+    ];
+  }
+
+  return array;
+}


### PR DESCRIPTION
- Add `nixpacks.toml` for building on Railway
- Shuffle initial index queue to avoid overloading hosts