### PR TITLE
fix(indexer): speed up populate queue query

### DIFF
--- a/examples/metadata-indexer/src/migrations/001_initial_migration.ts
+++ b/examples/metadata-indexer/src/migrations/001_initial_migration.ts
@@ -140,6 +140,12 @@ export const up = async (db: DB) => {
     .on("castEmbedUrls")
     .column("castHash")
     .execute();
+
+  await db.schema
+    .createIndex("cast_embed_urls_cast_url_index")
+    .on("castEmbedUrls")
+    .column("url")
+    .execute();
 };
 
 export const down = async (db: DB) => {


### PR DESCRIPTION
- Add index on the url column of `cast_embed_urls`
- Temporarily replace Kysely query to select unindexed urls with raw SQL (Kysely query was hanging, will investigate further)