### PR TITLE
fix(opengraph): include zora token id in metadata lookup

### DIFF
--- a/examples/api/src/app/api/open-graph/lib/url-handlers/zora.ts
+++ b/examples/api/src/app/api/open-graph/lib/url-handlers/zora.ts
@@ -6,6 +6,7 @@ async function handleZoraCollectUrl(url: string): Promise<UrlMetadata | null> {
   const parsedUrl = new URL(url);
   const pathname = parsedUrl.pathname;
   const pathParts = pathname.split("/");
+  const tokenId = pathParts[3];
   const chainAndContractAddress = pathParts[2].toLowerCase();
   let [chain, contractAddress] = chainAndContractAddress.split(":");
 
@@ -22,6 +23,7 @@ async function handleZoraCollectUrl(url: string): Promise<UrlMetadata | null> {
 
   const nftMetadata = await fetchNFTMetadata({
     contractAddress,
+    tokenId,
     chain,
     mintUrl: url,
   });


### PR DESCRIPTION
Fix an issue where individual NFT tokens were not indexed alongside collection when linked to in zora collect url.