### PR TITLE
fix(cast-embed-metadata): fix missing attributes in res

### DIFF
--- a/docs/pages/metadata-cache.mdx
+++ b/docs/pages/metadata-cache.mdx
@@ -58,7 +58,9 @@ This will return a JSON object with the following structure:
       "metadata": {
         "title": "Example Title",
         "description": "Example Description",
-        "image": "https://example.com/image.png"
+        "image": { 
+          url: "https://example.com/image.png"
+        }
         // ...
       }
     }

--- a/examples/api/src/app/api/cast-embeds-metadata/route.ts
+++ b/examples/api/src/app/api/cast-embeds-metadata/route.ts
@@ -38,7 +38,42 @@ export async function POST(request: NextRequest) {
         "url_metadata.nft_collection_id",
         "nft_collections.id"
       )
-      .selectAll()
+      .select([
+        /* Select all columns with aliases to prevent collisions */
+
+        // Cast metadata
+        "casts.hash as hash",
+        "cast_embed_urls.url as url",
+        "cast_embed_urls.unnormalized_url as unnormalized_url",
+        "index",
+
+        // URL metadata
+        "url_metadata.image_url as url_image_url",
+        "url_metadata.image_height as url_image_height",
+        "url_metadata.image_width as url_image_width",
+        "url_metadata.alt as url_alt",
+        "url_metadata.description as url_description",
+        "url_metadata.title as url_title",
+        "url_metadata.publisher as url_publisher",
+        "url_metadata.logo_url as url_logo_url",
+        "url_metadata.mime_type as url_mime_type",
+        "url_metadata.nft_collection_id as nft_collection_id",
+        "url_metadata.nft_metadata_id as nft_metadata_id",
+
+        // NFT Collection metadata
+        "nft_collections.creator_address as collection_creator_address",
+        "nft_collections.description as collection_description",
+        "nft_collections.image_url as collection_image_url",
+        "nft_collections.item_count as collection_item_count",
+        "nft_collections.mint_url as collection_mint_url",
+        "nft_collections.name as collection_name",
+        "nft_collections.open_sea_url as collection_open_sea_url",
+        "nft_collections.owner_count as collection_owner_count",
+
+        // NFT metadata
+        "nft_metadata.token_id as nft_token_id",
+        "nft_metadata.media_url as nft_media_url",
+      ])
       .execute();
 
     const rowsFormatted: EmbedWithCastHash[] = metadata.map((row) => {
@@ -54,39 +89,39 @@ export async function POST(request: NextRequest) {
         const chain = chainById[chainId];
 
         nftMetadata = {
-          mediaUrl: row.media_url || undefined,
-          tokenId: row.token_id || undefined,
+          mediaUrl: row.nft_media_url || undefined,
+          tokenId: row.nft_token_id || undefined,
           collection: {
             chain: chain.network,
             contractAddress,
-            creatorAddress: row.creator_address,
-            description: row.description,
+            creatorAddress: row.collection_creator_address,
+            description: row.collection_description,
             id: row.nft_collection_id,
-            imageUrl: row.image_url,
-            itemCount: row.item_count,
-            mintUrl: row.mint_url,
-            name: row.name,
-            openSeaUrl: row.open_sea_url || undefined,
-            ownerCount: row.owner_count || undefined,
+            imageUrl: row.collection_image_url,
+            itemCount: row.collection_item_count,
+            mintUrl: row.collection_mint_url,
+            name: row.collection_name,
+            openSeaUrl: row.collection_open_sea_url || undefined,
+            ownerCount: row.collection_owner_count || undefined,
             creator: undefined, // TODO: Look up farcaster user by FID
           },
         };
       }
 
       const urlMetadata: UrlMetadata = {
-        image: row.image_url
+        image: row.url_image_url
           ? {
-              url: row.image_url,
-              height: row.image_height || undefined,
-              width: row.image_width || undefined,
+              url: row.url_image_url,
+              height: row.url_image_height || undefined,
+              width: row.url_image_width || undefined,
             }
           : undefined,
-        alt: row.alt || undefined,
-        description: row.description || undefined,
-        title: row.title || undefined,
-        publisher: row.publisher || undefined,
-        logo: row.logo_url ? { url: row.logo_url } : undefined,
-        mimeType: row.mime_type || undefined,
+        alt: row.url_alt || undefined,
+        description: row.url_description || undefined,
+        title: row.url_title || undefined,
+        publisher: row.url_publisher || undefined,
+        logo: row.url_logo_url ? { url: row.url_logo_url } : undefined,
+        mimeType: row.url_mime_type || undefined,
         nft: nftMetadata,
       };
 


### PR DESCRIPTION
Fix missing attributes in `cast-embed-metadata` response by explicitly selecting all database fields with aliases to prevent collisions.