### PR TITLE
fix(miniapp/nft-minter): render embed image

### DIFF
--- a/.changeset/tiny-trainers-lie.md
+++ b/.changeset/tiny-trainers-lie.md
@@ -1,0 +1,5 @@
+---
+"@miniapps/nft-minter": patch
+---
+
+fix: render embed image source instead of nft token image source

--- a/miniapps/nft-minter/src/view.ts
+++ b/miniapps/nft-minter/src/view.ts
@@ -3,7 +3,7 @@ import { ModElement } from "@mod-protocol/core";
 const view: ModElement[] = [
   {
     type: "card",
-    imageSrc: "{{embed.metadata.nft.mediaUrl}}",
+    imageSrc: "{{embed.metadata.image.url}}",
     aspectRatio: 16 / 11,
     topLeftBadge: "@{{embed.metadata.nft.collection.creator.username}}",
     onclick: {


### PR DESCRIPTION
Render the embed image instead of token image for nft minter card. Handles the case where the token image url is unavailable and avoids excessive null checks