### PR TITLE
fix(opengraph): handle zora premint url

### DIFF
--- a/.changeset/violet-cobras-shout.md
+++ b/.changeset/violet-cobras-shout.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+fix: handle zora premint urls

--- a/examples/api/src/app/api/open-graph/lib/url-handlers/fallback.ts
+++ b/examples/api/src/app/api/open-graph/lib/url-handlers/fallback.ts
@@ -38,12 +38,19 @@ const ethSearchParams = ethDataSelectors.map(
   }
 );
 
-async function fallbackUrlHandler(url: string): Promise<UrlMetadata> {
+async function fallbackUrlHandler(
+  url: string,
+  { nftMetadata }: { nftMetadata?: boolean } = { nftMetadata: true }
+): Promise<UrlMetadata> {
+  let metadataUrl = `https://pro.microlink.io/?url=${encodeURIComponent(url)}`;
+
+  if (nftMetadata) {
+    metadataUrl += `&${ethSearchParams.join("&")}`;
+  }
+
   const response = await fetch(
     // To self host, use https://github.com/microlinkhq/metascraper
-    `https://pro.microlink.io/?url=${encodeURIComponent(
-      url
-    )}&${ethSearchParams.join("&")}`,
+    `${metadataUrl}`,
     {
       headers: {
         "x-api-key": process.env.MICROLINK_API_KEY,

--- a/examples/api/src/app/api/open-graph/lib/url-handlers/index.ts
+++ b/examples/api/src/app/api/open-graph/lib/url-handlers/index.ts
@@ -3,8 +3,16 @@ import caip19 from "./caip-19";
 import fallback from "./fallback";
 import opensea from "./opensea";
 import zora from "./zora";
+import zoraPremint from "./zora-premint";
 import imageFileUrl from "./image-file";
 
-const handlers: UrlHandler[] = [opensea, zora, caip19, imageFileUrl, fallback];
+const handlers: UrlHandler[] = [
+  opensea,
+  zoraPremint,
+  zora,
+  caip19,
+  imageFileUrl,
+  fallback,
+];
 
 export default handlers;

--- a/examples/api/src/app/api/open-graph/lib/url-handlers/zora-premint.ts
+++ b/examples/api/src/app/api/open-graph/lib/url-handlers/zora-premint.ts
@@ -1,0 +1,15 @@
+import { UrlMetadata } from "@mod-protocol/core";
+import { UrlHandler } from "../../types/url-handler";
+import fallback from "./fallback";
+
+async function handleZoraPremintUrl(url: string): Promise<UrlMetadata | null> {
+  const metadata = fallback.handler(url, { nftMetadata: false });
+  return metadata;
+}
+
+const handler: UrlHandler = {
+  matchers: [/https:\/\/zora\.co\/collect\/([^\/]+):([^\/]+)\/(premint-\d+)/],
+  handler: handleZoraPremintUrl,
+};
+
+export default handler;

--- a/examples/api/src/app/api/open-graph/types/url-handler.ts
+++ b/examples/api/src/app/api/open-graph/types/url-handler.ts
@@ -2,5 +2,5 @@ import { UrlMetadata } from "@mod-protocol/core";
 
 export type UrlHandler = {
   matchers: (string | RegExp)[];
-  handler: (url: string) => Promise<UrlMetadata>;
+  handler: (url: string, options?: any) => Promise<UrlMetadata>;
 };


### PR DESCRIPTION
Zora premint urls contain NFT opengraph extension tags, but trying to fetch the NFT metadata for it fails because it's not deployed yet.

This PR addresses this issue by matching zora premint URLs using the `/premint-<token id>` URL suffix and handling it using the fallback URL handler, which has been extended to take in a configuration object with a key `nftMetadata` which defaults to true.