### PR TITLE
fix(opengraph): stability and coverage improvements

### DIFF
--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -15,6 +15,7 @@
     "chatgpt": "^5.2.5",
     "kysely": "^0.26.3",
     "next": "^13.5.6",
+    "open-graph-scraper": "^6.3.2",
     "pg": "^8.11.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/api/src/app/api/open-graph/lib/url-handlers/caip-19.ts
+++ b/examples/api/src/app/api/open-graph/lib/url-handlers/caip-19.ts
@@ -46,6 +46,7 @@ async function handleCaip19Url(url: string): Promise<UrlMetadata | null> {
 }
 
 const urlHandler: UrlHandler = {
+  name: "CAIP-19",
   matchers: ["^chain://"],
   handler: handleCaip19Url,
 };

--- a/examples/api/src/app/api/open-graph/lib/url-handlers/image-file.ts
+++ b/examples/api/src/app/api/open-graph/lib/url-handlers/image-file.ts
@@ -32,6 +32,7 @@ async function handleImageFileUrl(url: string): Promise<UrlMetadata | null> {
 }
 
 const handler: UrlHandler = {
+  name: "Image File",
   matchers: [/\.((jpg|jpeg|png|gif|bmp|webp|tiff|svg))(?=\?|$)/i],
   handler: handleImageFileUrl,
 };

--- a/examples/api/src/app/api/open-graph/lib/url-handlers/index.ts
+++ b/examples/api/src/app/api/open-graph/lib/url-handlers/index.ts
@@ -1,10 +1,11 @@
 import { UrlHandler } from "../../types/url-handler";
 import caip19 from "./caip-19";
-import fallback from "./fallback";
 import opensea from "./opensea";
 import zora from "./zora";
 import zoraPremint from "./zora-premint";
 import imageFileUrl from "./image-file";
+import metascraper from "./metascraper";
+import localFetch from "./local-fetch";
 
 const handlers: UrlHandler[] = [
   opensea,
@@ -12,7 +13,8 @@ const handlers: UrlHandler[] = [
   zora,
   caip19,
   imageFileUrl,
-  fallback,
+  localFetch,
+  metascraper,
 ];
 
 export default handlers;

--- a/examples/api/src/app/api/open-graph/lib/url-handlers/local-fetch.ts
+++ b/examples/api/src/app/api/open-graph/lib/url-handlers/local-fetch.ts
@@ -1,0 +1,104 @@
+import { NFTMetadata, UrlMetadata } from "@mod-protocol/core";
+import ogs from "open-graph-scraper";
+import { UrlHandler } from "../../types/url-handler";
+import { chainById } from "../chains/chain-index";
+import { fetchNFTMetadata } from "../util";
+
+async function localFetchHandler(url: string): Promise<UrlMetadata> {
+  const userAgent = "bot";
+  const response = await fetch(url, {
+    headers: { "user-agent": userAgent, Accept: "text/html" },
+  });
+
+  const html = await response.text();
+
+  const { result: data } = await ogs({
+    html,
+    customMetaTags: [
+      {
+        multiple: false,
+        property: "eth:nft:contract_address",
+        fieldName: "ethNftContractAddress",
+      },
+      {
+        multiple: false,
+        property: "eth:nft:chain",
+        fieldName: "ethNftChain",
+      },
+      {
+        multiple: false,
+        property: "nft:chain",
+        fieldName: "ethNftChainAlt",
+      },
+      {
+        multiple: false,
+        property: "eth:nft:mint_url",
+        fieldName: "ethNftMintUrl",
+      },
+    ],
+  });
+
+  let nftMetadata: NFTMetadata | undefined;
+  if (data["customMetaTags"]["ethNftContractAddress"]) {
+    const {
+      ethNftContractAddress,
+      ethNftChain,
+      ethNftChainAlt,
+      ethNftMintUrl,
+    } = data["customMetaTags"];
+    let contractAddress: string | undefined = ethNftContractAddress;
+    let chain: string | undefined = (
+      ethNftChain ||
+      ethNftChainAlt ||
+      "ethereum"
+    ).toLowerCase();
+    const mintUrl = ethNftMintUrl || url;
+
+    // Handle case where contractAddress is in the form of <chain>:<contractAddress>
+    if (contractAddress && contractAddress.includes(":")) {
+      [chain, contractAddress] = contractAddress.split(":");
+    }
+
+    // Handle case where chain is chain ID instead of chain name
+    if (!Number.isNaN(parseInt(chain))) {
+      chain = chainById[parseInt(chain)].network;
+    }
+
+    nftMetadata = await fetchNFTMetadata({
+      contractAddress,
+      chain,
+      mintUrl,
+    });
+  }
+
+  const urlMetadata: UrlMetadata = {
+    title: data.ogTitle,
+    description: data.ogDescription || data.twitterDescription,
+    image: data.ogImage?.length > 0 ? data.ogImage[0] : undefined,
+    logo: data.ogLogo
+      ? {
+          url: data.ogLogo,
+        }
+      : undefined,
+    publisher: data.ogSiteName,
+    mimeType: response["headers"]["content-type"],
+    nft: nftMetadata,
+  };
+
+  if (response["status"] !== 200) {
+    console.error(
+      `[Local Fetch] Fetch failed for ${url} [${response["status"]}]`
+    );
+    return null;
+  }
+
+  return urlMetadata;
+}
+
+const handler: UrlHandler = {
+  name: "Local Fetch",
+  matchers: [".*"],
+  handler: localFetchHandler,
+};
+
+export default handler;

--- a/examples/api/src/app/api/open-graph/lib/url-handlers/opensea.ts
+++ b/examples/api/src/app/api/open-graph/lib/url-handlers/opensea.ts
@@ -53,6 +53,7 @@ async function handleOpenSeaUrl(url: string): Promise<UrlMetadata | null> {
 }
 
 const urlHandler: UrlHandler = {
+  name: "OpenSea",
   matchers: [
     "https://opensea.io/assets/.*",
     "https://opensea.io/collection/.*",

--- a/examples/api/src/app/api/open-graph/lib/url-handlers/zora-premint.ts
+++ b/examples/api/src/app/api/open-graph/lib/url-handlers/zora-premint.ts
@@ -1,6 +1,6 @@
 import { UrlMetadata } from "@mod-protocol/core";
 import { UrlHandler } from "../../types/url-handler";
-import fallback from "./fallback";
+import fallback from "./metascraper";
 
 async function handleZoraPremintUrl(url: string): Promise<UrlMetadata | null> {
   const metadata = fallback.handler(url, { nftMetadata: false });
@@ -8,6 +8,7 @@ async function handleZoraPremintUrl(url: string): Promise<UrlMetadata | null> {
 }
 
 const handler: UrlHandler = {
+  name: "Zora Premint",
   matchers: [/https:\/\/zora\.co\/collect\/([^\/]+):([^\/]+)\/(premint-\d+)/],
   handler: handleZoraPremintUrl,
 };

--- a/examples/api/src/app/api/open-graph/lib/url-handlers/zora.ts
+++ b/examples/api/src/app/api/open-graph/lib/url-handlers/zora.ts
@@ -34,6 +34,7 @@ async function handleZoraCollectUrl(url: string): Promise<UrlMetadata | null> {
 }
 
 const handler: UrlHandler = {
+  name: "Zora Collect",
   matchers: ["https://zora.co/collect/.*"],
   handler: handleZoraCollectUrl,
 };

--- a/examples/api/src/app/api/open-graph/route.ts
+++ b/examples/api/src/app/api/open-graph/route.ts
@@ -1,4 +1,5 @@
 export const dynamic = "force-dynamic";
+export const maxDuration = 20;
 
 import { NextResponse, NextRequest } from "next/server";
 import { UrlMetadata } from "@mod-protocol/core";
@@ -8,15 +9,21 @@ export async function GET(request: NextRequest) {
   const url = decodeURIComponent(request.nextUrl.searchParams.get("url"));
   try {
     let urlMetadata: UrlMetadata | null = null;
-    for (const { matchers, handler } of urlHandlers) {
+    let handlerName: string | null = null;
+    for (const { matchers, handler, name } of urlHandlers) {
       if (matchers.some((matcher) => url.match(matcher))) {
         urlMetadata = await handler(url);
+        handlerName = name;
         // Stop after successful match
         if (urlMetadata) break;
       }
     }
 
-    return NextResponse.json(urlMetadata);
+    if (!urlMetadata) {
+      throw new Error(`No handler returned a valid response for ${url}`);
+    }
+
+    return NextResponse.json({ ...urlMetadata, handlerName });
   } catch (err) {
     console.error(`Error fetching metadata for ${url}`);
     console.error(err);

--- a/examples/api/src/app/api/open-graph/types/url-handler.ts
+++ b/examples/api/src/app/api/open-graph/types/url-handler.ts
@@ -1,6 +1,7 @@
 import { UrlMetadata } from "@mod-protocol/core";
 
 export type UrlHandler = {
+  name: string;
   matchers: (string | RegExp)[];
   handler: (url: string, options?: any) => Promise<UrlMetadata>;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -725,6 +725,11 @@
     "@noble/hashes" "^1.3.0"
     neverthrow "^6.0.0"
 
+"@fastify/busboy@^2.0.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.0.tgz#0709e9f4cb252351c609c6e6d8d6779a8d25edff"
+  integrity sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==
+
 "@floating-ui/core@^1.4.2":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.5.0.tgz#5c05c60d5ae2d05101c3021c1a2a350ddc027f8c"
@@ -3266,6 +3271,11 @@ bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -3538,6 +3548,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+chardet@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-2.0.0.tgz#24a74bd3954965ba2d30f490a915fc3cf053051f"
+  integrity sha512-xVgPpulCooDjY6zH4m9YW3jbkaBe3FKIAvF5sj5t7aBNsVl2ljIE+xwJ4iNgiDZHFQvNIpjdKdVOQvvk5ZfxbQ==
+
 chatgpt@^5.2.5:
   version "5.2.5"
   resolved "https://registry.yarnpkg.com/chatgpt/-/chatgpt-5.2.5.tgz#6a9f951fd58d8501ff0384a338eacdc0e3d8544f"
@@ -3552,6 +3567,31 @@ chatgpt@^5.2.5:
     quick-lru "^6.1.1"
     read-pkg-up "^9.1.0"
     uuid "^9.0.0"
+
+cheerio-select@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-2.1.0.tgz#4d8673286b8126ca2a8e42740d5e3c4884ae21b4"
+  integrity sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==
+  dependencies:
+    boolbase "^1.0.0"
+    css-select "^5.1.0"
+    css-what "^6.1.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+
+cheerio@^1.0.0-rc.12:
+  version "1.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.12.tgz#788bf7466506b1c6bf5fae51d24a2c4d62e47683"
+  integrity sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==
+  dependencies:
+    cheerio-select "^2.1.0"
+    dom-serializer "^2.0.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+    htmlparser2 "^8.0.1"
+    parse5 "^7.0.0"
+    parse5-htmlparser2-tree-adapter "^7.0.0"
 
 chokidar@^3.5.1, chokidar@^3.5.3:
   version "3.5.3"
@@ -3835,6 +3875,22 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
+css-what@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -4403,15 +4459,45 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
 dom-walk@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.2.tgz#0c548bef048f4d1f2a97249002236060daa3fd84"
   integrity sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==
 
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
 dompurify@^3.0.5:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.0.6.tgz#925ebd576d54a9531b5d76f0a5bef32548351dae"
   integrity sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w==
+
+domutils@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
+  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
 
 dot-case@^2.1.0:
   version "2.1.1"
@@ -4485,7 +4571,7 @@ enquirer@^2.3.0, enquirer@^2.3.5:
     ansi-colors "^4.1.1"
     strip-ansi "^6.0.1"
 
-entities@^4.4.0:
+entities@^4.2.0, entities@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
@@ -5964,6 +6050,16 @@ html-void-elements@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
   integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
+
+htmlparser2@^8.0.1:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.2.tgz#f002151705b383e62433b5cf466f5b716edaec21"
+  integrity sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+    entities "^4.4.0"
 
 http-cache-semantics@^4.0.0:
   version "4.1.1"
@@ -8508,6 +8604,13 @@ npm-to-yarn@^2.1.0:
   resolved "https://registry.yarnpkg.com/npm-to-yarn/-/npm-to-yarn-2.1.0.tgz#ff4e18028d18eb844691f1ccb556be5f3ccfde34"
   integrity sha512-2C1IgJLdJngq1bSER7K7CGFszRr9s2rijEwvENPEgI0eK9xlD3tNwDc0UJnRj7FIT2aydWm72jB88uVswAhXHA==
 
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+  dependencies:
+    boolbase "^1.0.0"
+
 object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -8620,6 +8723,16 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+open-graph-scraper@^6.3.2:
+  version "6.3.2"
+  resolved "https://registry.yarnpkg.com/open-graph-scraper/-/open-graph-scraper-6.3.2.tgz#ce64641aa7da2b677d8f1bafd64cbbf2c6c5716c"
+  integrity sha512-3HbQwpSZ42hqqpDmZ3ZUOCuS1TuKqRWm6gEIw/HfqWDzwHaEJJR/WGi1prHD2gBaKYPjAHFaSTjKitJHTwMVPA==
+  dependencies:
+    chardet "^2.0.0"
+    cheerio "^1.0.0-rc.12"
+    undici "^5.26.4"
+    validator "^13.11.0"
 
 optionator@^0.9.1, optionator@^0.9.3:
   version "0.9.3"
@@ -8849,6 +8962,14 @@ parse-url@^8.1.0:
   integrity sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==
   dependencies:
     parse-path "^7.0.0"
+
+parse5-htmlparser2-tree-adapter@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz#23c2cc233bcf09bb7beba8b8a69d46b08c62c2f1"
+  integrity sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==
+  dependencies:
+    domhandler "^5.0.2"
+    parse5 "^7.0.0"
 
 parse5@^7.0.0:
   version "7.1.2"
@@ -11087,6 +11208,13 @@ undici-types@~5.26.4:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
+undici@^5.26.4:
+  version "5.27.2"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.27.2.tgz#a270c563aea5b46cc0df2550523638c95c5d4411"
+  integrity sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==
+  dependencies:
+    "@fastify/busboy" "^2.0.0"
+
 unified@^10.0.0:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/unified/-/unified-10.1.2.tgz#b1d64e55dafe1f0b98bb6c719881103ecf6c86df"
@@ -11363,6 +11491,11 @@ validate-npm-package-name@^5.0.0:
   integrity sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==
   dependencies:
     builtins "^5.0.0"
+
+validator@^13.11.0:
+  version "13.11.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.11.0.tgz#23ab3fd59290c61248364eabf4067f04955fbb1b"
+  integrity sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==
 
 vfile-location@^5.0.0:
   version "5.0.2"


### PR DESCRIPTION
Stability improvements for the opengraph endpoint to more reliably retrieve opengraph information from sites
- Add local fetch handler 
- Rename fallback handler to metascraper handler
- Prioritize local fetch over metascraper
- Add handler name to response

This PR also includes a fix an issue in the `cast-embeds-metadata` endpoint which caused it to exclude casts which don't have embeds from the response. It now includes those casts with an empty array.