### PR TITLE
fix(opengraph/indexer): optional mintUrl, 1155 mint url support

### DIFF
--- a/.changeset/large-mirrors-march.md
+++ b/.changeset/large-mirrors-march.md
@@ -1,0 +1,6 @@
+---
+"@miniapps/zora-nft-minter": patch
+"@miniapps/nft-minter": patch
+---
+
+fix: support fallback mint URL

--- a/.changeset/stupid-cougars-cross.md
+++ b/.changeset/stupid-cougars-cross.md
@@ -1,0 +1,6 @@
+---
+"@mod-protocol/core": minor
+"api": minor
+---
+
+fix: optional mint URL opengraph response, mint URL for ERC-1155 tokens

--- a/examples/api/src/app/api/cast-embeds-metadata/route.ts
+++ b/examples/api/src/app/api/cast-embeds-metadata/route.ts
@@ -28,6 +28,7 @@ function formatRow(row): EmbedWithCastHash {
     nftMetadata = {
       mediaUrl: row.nft_media_url || undefined,
       tokenId: row.nft_token_id || undefined,
+      mintUrl: row.nft_mint_url || row.collection_mint_url || undefined,
       collection: {
         chain: chain.network,
         contractAddress,
@@ -135,6 +136,7 @@ export async function POST(request: NextRequest) {
         // NFT metadata
         "nft_metadata.token_id as nft_token_id",
         "nft_metadata.media_url as nft_media_url",
+        "nft_metadata.mint_url as nft_mint_url",
       ])
       .execute();
 

--- a/examples/api/src/app/api/cast-embeds-metadata/types/db.d.ts
+++ b/examples/api/src/app/api/cast-embeds-metadata/types/db.d.ts
@@ -39,7 +39,7 @@ export interface NftCollections {
   id: string;
   image_url: string | null;
   item_count: number;
-  mint_url: string;
+  mint_url: string | null;
   name: string;
   open_sea_url: string | null;
   owner_count: number;
@@ -50,6 +50,7 @@ export interface NftMetadata {
   created_at: Generated<Timestamp>;
   id: string;
   media_url: string | null;
+  mint_url: string | null;
   nft_collection_id: string;
   token_id: string;
   updated_at: Generated<Timestamp>;

--- a/examples/api/src/app/api/open-graph/lib/util.ts
+++ b/examples/api/src/app/api/open-graph/lib/util.ts
@@ -165,6 +165,8 @@ export async function fetchNFTMetadata({
     mediaUrl: image,
     tokenId: tokenId,
     owner: ownerFcUser,
+    // If this is a link to a token and it is part of an ERC1155 collection, include the mint url in token metadata
+    mintUrl: tokenId && tokenStandard === "erc1155" ? mintUrl : undefined,
     collection: {
       id: collectionCaip19Uri,
       chain: chain,
@@ -175,7 +177,8 @@ export async function fetchNFTMetadata({
       itemCount: collectionStats.stats.count,
       ownerCount: collectionStats.stats.num_owners,
       imageUrl: image,
-      mintUrl: mintUrl || collectionData.opensea_url,
+      // Always include the mint url if it was specified
+      mintUrl: mintUrl,
       openSeaUrl: collectionData.opensea_url,
       creator: creatorFcUser,
     },

--- a/examples/metadata-indexer/src/db.ts
+++ b/examples/metadata-indexer/src/db.ts
@@ -67,7 +67,7 @@ export type NftCollectionRow = {
   itemCount: number;
   ownerCount: number;
   imageUrl: string | null;
-  mintUrl: string;
+  mintUrl: string | null;
   openSeaUrl: string | null;
   creatorFid: Fid | null;
 };
@@ -78,6 +78,7 @@ export type NftMetadataRow = {
   updatedAt: Generated<Date>;
   tokenId: string;
   mediaUrl: string | null;
+  mintUrl: string | null; // Overrides collection mintUrl
   nftCollectionId: string;
 };
 

--- a/examples/metadata-indexer/src/indexerQueue.ts
+++ b/examples/metadata-indexer/src/indexerQueue.ts
@@ -177,6 +177,7 @@ export class IndexerQueue {
           tokenId: result.nft.tokenId,
           mediaUrl: result.nft.mediaUrl,
           nftCollectionId: nftCollectionId,
+          mintUrl: result.nft.mintUrl,
         })
         .onConflict((oc) => oc.columns(["id"]).doNothing())
         .execute();

--- a/examples/metadata-indexer/src/migrations/001_initial_migration.ts
+++ b/examples/metadata-indexer/src/migrations/001_initial_migration.ts
@@ -77,7 +77,7 @@ export const up = async (db: DB) => {
     .addColumn("creatorAddress", "text", (col) => col.notNull())
     .addColumn("itemCount", "integer", (col) => col.notNull())
     .addColumn("ownerCount", "integer", (col) => col.notNull())
-    .addColumn("mintUrl", "text", (col) => col.notNull())
+    .addColumn("mintUrl", "text")
     .addColumn("description", "text")
     .addColumn("imageUrl", "text")
     .addColumn("openSeaUrl", "text")
@@ -108,6 +108,7 @@ export const up = async (db: DB) => {
     .addColumn("tokenId", "text", (col) => col.notNull())
     .addColumn("mediaUrl", "text", (col) => col)
     .addColumn("nftCollectionId", "text", (col) => col.notNull())
+    .addColumn("mintUrl", "text")
     .$call((qb) => qb.addPrimaryKeyConstraint("nftMetadata_pkey", ["id"]))
     .execute();
 

--- a/miniapps/nft-minter/src/view.ts
+++ b/miniapps/nft-minter/src/view.ts
@@ -24,9 +24,24 @@ const view: ModElement[] = [
             label: "{{embed.metadata.nft.collection.name}}",
           },
           {
-            type: "link",
-            label: "Mint",
-            url: "{{embed.metadata.nft.collection.mintUrl}}",
+            if: {
+              value: "{{embed.metadata.nft.mintUrl}}",
+              match: {
+                NOT: {
+                  equals: "",
+                },
+              },
+            },
+            then: {
+              type: "link",
+              label: "Mint",
+              url: "{{embed.metadata.nft.mintUrl}}",
+            },
+            else: {
+              type: "link",
+              label: "View collection",
+              url: "{{embed.metadata.nft.collection.openSeaUrl}}",
+            },
           },
         ],
       },

--- a/miniapps/zora-nft-minter/src/view.ts
+++ b/miniapps/zora-nft-minter/src/view.ts
@@ -107,7 +107,7 @@ const view: ModElement[] = [
               label: "Mint",
               onclick: {
                 type: "OPENLINK",
-                url: "{{embed.metadata.nft.collection.mintUrl}}",
+                url: "{{embed.metadata.nft.mintUrl}}",
               },
             },
           },

--- a/packages/core/src/embeds.ts
+++ b/packages/core/src/embeds.ts
@@ -33,6 +33,7 @@ export type NFTMetadata = {
   owner?: FarcasterUser;
   tokenId?: string;
   mediaUrl?: string;
+  mintUrl?: string;
   collection: {
     id: string;
     name: string;
@@ -41,7 +42,7 @@ export type NFTMetadata = {
     creatorAddress: string;
     itemCount: number;
     ownerCount: number;
-    mintUrl: string;
+    mintUrl?: string;
     description?: string;
     imageUrl?: string;
     openSeaUrl?: string;


### PR DESCRIPTION
- Adds `mintUrl` to the NFT token type to support the different mint URLs for each token in ERC1155 token standard
- Makes `mintUrl` optional on the collection type instead of falling back to an opensea collection URL