### PR TITLE
feat: initial mod action paste handler example

### DIFF
--- a/.changeset/dry-bikes-joke.md
+++ b/.changeset/dry-bikes-joke.md
@@ -1,0 +1,6 @@
+---
+"@mod-protocol/react": patch
+"@mod-protocol/core": patch
+---
+
+feat: add public `triggerActionWithContext` method and initial event/context for programmatically triggering mod actions externally

--- a/.changeset/witty-bottles-lay.md
+++ b/.changeset/witty-bottles-lay.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+feat: add paste handler for images

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1024,6 +1024,11 @@ export class Renderer {
     }
   }
 
+  public triggerActionWithContext(action: ModEvent, context: any) {
+    this.refs = context;
+    this.stepIntoOrTriggerAction(action);
+  }
+
   private stepIntoOrTriggerAction(maybeElementTreeOrAction: ModEvent): void {
     if (this.interrupted) {
       return;

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -15,6 +15,7 @@ import {
   CreationContext,
   EthPersonalSignActionResolver,
   SendEthTransactionActionResolver,
+  ModEvent,
 } from "@mod-protocol/core";
 import actionResolverHttp from "./action-resolver-http";
 import actionResolverOpenFile from "./action-resolver-open-file";
@@ -429,6 +430,8 @@ export type ResolverTypes = {
 type Props = ResolverTypes & {
   manifest: ModManifest;
   renderers: Renderers;
+  initialContext?: any;
+  initialAction?: ModEvent;
 };
 
 export const CreationMod = (
@@ -437,6 +440,8 @@ export const CreationMod = (
   const {
     manifest,
     variant,
+    initialAction,
+    initialContext,
     onHttpAction = actionResolverHttp,
     onOpenFileAction = actionResolverOpenFile,
     onSetInputAction = actionResolverSetInput,
@@ -477,6 +482,11 @@ export const CreationMod = (
     renderer.setContext(context);
     forceRerender();
   }, [forceRerender, context, renderer]);
+
+  React.useEffect(() => {
+    if (initialAction)
+      renderer.triggerActionWithContext(initialAction, initialContext);
+  }, [initialAction, initialContext, renderer]);
 
   return <Mod {...props} renderer={renderer} />;
 };


### PR DESCRIPTION
## Change Summary

Adds `initialAction` and `initialContext` to the CreationMod component, which calls `triggerActionWithContext` in the `Renderer` on initial mount. This enables clients to specify an initial action for the Mod to take with pre-populated context such as when pasting an image (implemented in `editor-example.tsx`)

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a changeset
- [x] PR includes documentation if necessary
- [x] PR updates the [rich-embed examples](https://github.com/mod-protocol/mod/blob/main/examples/nextjs-shadcn/src/app/embeds.tsx) if necessary
- [x] includes a parallel PR for [Mod-starter](https://github.com/mod-protocol/mod-starter) and the gateway if necessary
