### PR TITLE
fix(opengraph): migrate to v2 opensea nft metadata collection stats endpoint

### DIFF
--- a/.changeset/polite-dancers-add.md
+++ b/.changeset/polite-dancers-add.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+fix: v2 opensea collection data api

--- a/examples/api/src/app/api/open-graph/lib/util.ts
+++ b/examples/api/src/app/api/open-graph/lib/util.ts
@@ -142,7 +142,7 @@ export async function fetchNFTMetadata({
   const collectionData = await collectionResponse.json();
 
   const collectionStatsResponse = await fetch(
-    `https://api.opensea.io/api/v1/collection/${collectionSlug}/stats`,
+    `https://api.opensea.io/api/v2/collections/${collectionSlug}/stats`,
     authOptions
   );
   // Collection stats should exist if the collection exists
@@ -177,8 +177,8 @@ export async function fetchNFTMetadata({
       creatorAddress: collectionData.owner,
       name: collectionData.name,
       description: collectionData.description,
-      itemCount: collectionStats.stats.count,
-      ownerCount: collectionStats.stats.num_owners,
+      itemCount: collectionStats.total.count || 0,
+      ownerCount: collectionStats.total.num_owners,
       imageUrl: image,
       // Always include the mint url if it was specified
       mintUrl: mintUrl,


### PR DESCRIPTION
## Change Summary

The opengraph endpoint currently doesn't return NFT metadata because the v1 endpoint for collection stats has been removed from the OpenSea API as per the response messsage:

```
{
    message: 'The /v1 API has been removed. Please migrate to /v2, documentation here: https://docs.opensea.io/reference/api-overview'
}
```

This change migrates to the [v2 opensea API](https://docs.opensea.io/reference/get_collection_stats), which does unfortunately not return the number of items in the collection. Hence the `itemCount` property of the NFT response now returns 0. A separate issue will be opened to address this.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a changeset
- [x] PR includes documentation if necessary
- [x] PR updates the [rich-embed examples](https://github.com/mod-protocol/mod/blob/main/examples/nextjs-shadcn/src/app/embeds.tsx) if necessary
- [x] includes a parallel PR for [Mod-starter](https://github.com/mod-protocol/mod-starter) and the gateway if necessary
