### PR TITLE
fix(react-ui-shadcn): text renderer overflow

### DIFF
--- a/.changeset/lemon-fishes-warn.md
+++ b/.changeset/lemon-fishes-warn.md
@@ -1,0 +1,5 @@
+---
+"@mod-protocol/react-ui-shadcn": patch
+---
+
+fix: overflow issue with long urls in text renderer

--- a/packages/react-ui-shadcn/src/renderers/text.tsx
+++ b/packages/react-ui-shadcn/src/renderers/text.tsx
@@ -3,7 +3,7 @@ import { Renderers } from "@mod-protocol/react";
 import { cva } from "class-variance-authority";
 import { cn } from "../lib/utils";
 
-const textVariants = cva("my-0 flex-1 text-sm", {
+const textVariants = cva("my-0 flex-1 text-sm break-words", {
   variants: {
     variant: {
       bold: "font-bold",


### PR DESCRIPTION
## Change Summary

Fixes #63 

<img width="428" alt="Screenshot 2023-12-18 at 16 04 19" src="https://github.com/mod-protocol/mod/assets/5469870/9cbf2bdc-5fa9-4e44-ba7d-82b03c2883dc">


## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a changeset
- [x] PR includes documentation if necessary
- [x] PR updates the [rich-embed examples](https://github.com/mod-protocol/mod/blob/main/examples/nextjs-shadcn/src/app/embeds.tsx) if necessary
- [x] includes a parallel PR for [Mod-starter](https://github.com/mod-protocol/mod-starter) and the gateway if necessary
