### PR TITLE
fix(react-editor): remaining characters shouldn't count mentions

### DIFF
--- a/.changeset/serious-teachers-kiss.md
+++ b/.changeset/serious-teachers-kiss.md
@@ -1,0 +1,5 @@
+---
+"@mod-protocol/react-editor": patch
+---
+
+fix: editor shouldn't take mentions into account when calculating remaining characters in cast text

--- a/packages/react-editor/src/use-text-length.tsx
+++ b/packages/react-editor/src/use-text-length.tsx
@@ -1,3 +1,5 @@
+import { convertCastPlainTextToStructured } from "@mod-protocol/farcaster";
+
 export function useTextLength({
   getText,
   maxByteLength,
@@ -6,7 +8,15 @@ export function useTextLength({
   maxByteLength: number;
 }) {
   const text = getText();
-  const lengthInBytes = new TextEncoder().encode(text).length;
+
+  // Mentions don't occupy space in the cast, so we need to ignore them for our length calculation
+  const structuredTextUnits = convertCastPlainTextToStructured({ text });
+  const textWithoutMentions = structuredTextUnits.reduce((acc, unit) => {
+    if (unit.type !== "mention") acc += unit.serializedContent;
+    return acc;
+  }, "");
+
+  const lengthInBytes = new TextEncoder().encode(textWithoutMentions).length;
 
   const eightyFivePercentComplete = maxByteLength * 0.85;
 


### PR DESCRIPTION
## Change Summary

Updates the `useTextLength` hook to not take mentioned usernames into account when calculating the remaining characters in the cast.

Fixes #122 

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a changeset
- [x] PR includes documentation if necessary
- [x] PR updates the [rich-embed examples](https://github.com/mod-protocol/mod/blob/main/examples/nextjs-shadcn/src/app/embeds.tsx) if necessary
- [x] includes a parallel PR for [Mod-starter](https://github.com/mod-protocol/mod-starter) and the gateway if necessary
