### PR TITLE
fix(api): fix `/cast-embeds-metadata` CORS error

### DIFF
--- a/.changeset/cyan-olives-tell.md
+++ b/.changeset/cyan-olives-tell.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+fix: `/cast-embeds-metadata` CORS error

--- a/examples/api/src/app/api/cast-embeds-metadata/by-url/route.ts
+++ b/examples/api/src/app/api/cast-embeds-metadata/by-url/route.ts
@@ -129,3 +129,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ message: err.message }, { status: err.status });
   }
 }
+
+// needed for preflight requests to succeed
+export const OPTIONS = async (request: NextRequest) => {
+  // Return Response
+  return NextResponse.json({});
+};

--- a/examples/api/src/app/api/cast-embeds-metadata/route.ts
+++ b/examples/api/src/app/api/cast-embeds-metadata/route.ts
@@ -161,3 +161,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ message: err.message }, { status: err.status });
   }
 }
+
+// needed for preflight requests to succeed
+export const OPTIONS = async (request: NextRequest) => {
+  // Return Response
+  return NextResponse.json({});
+};


### PR DESCRIPTION
## Change Summary

Adds an empty response to the `/cast-embeds-metadata` and `/cast-embeds-metadata/by-url` routes for the OPTIONS method which should resolve any CORS errors when trying to call the API from within a browser.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a changeset
- [x] PR includes documentation if necessary
- [x] PR updates the [rich-embed examples](https://github.com/mod-protocol/mod/blob/main/examples/nextjs-shadcn/src/app/embeds.tsx) if necessary
- [x] includes a parallel PR for [Mod-starter](https://github.com/mod-protocol/mod-starter) and the gateway if necessary
