### PR TITLE
fix(react): debounce onload events

### DIFF
--- a/.changeset/violet-chairs-clap.md
+++ b/.changeset/violet-chairs-clap.md
@@ -1,0 +1,5 @@
+---
+"@mod-protocol/react": patch
+---
+
+fix: debounce onload event calling to prevent infinite calling (#135)

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -630,6 +630,7 @@ export class Renderer {
 
                 if (action.ref) {
                   set(this.refs, action.ref, { response, progress: 100 });
+                  this.onTreeChange();
                 }
 
                 if (action.onsuccess) {
@@ -651,6 +652,7 @@ export class Renderer {
 
                 if (action.ref) {
                   set(this.refs, action.ref, { error });
+                  this.onTreeChange();
                 }
 
                 this.asyncAction = null;

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -175,7 +175,12 @@ const WrappedHorizontalLayoutRenderer = <T extends React.ReactNode>(props: {
   element: Extract<ModElementRef<T>, { type: "horizontal-layout" }>;
 }) => {
   const { component: Component, element } = props;
-  const { events, type, elements, ...rest } = element;
+  const { type, elements, ...rest } = element;
+
+  // Prevents the onLoad event from being called multiple times when
+  // the tree changes and reference to the events object changes.
+  // Assumes events are immutable over the lifecycle of a component
+  const [events] = React.useState(element.events);
 
   React.useEffect(() => {
     events.onLoad();
@@ -189,7 +194,10 @@ const WrappedVerticalLayoutRenderer = <T extends React.ReactNode>(props: {
   element: Extract<ModElementRef<T>, { type: "vertical-layout" }>;
 }) => {
   const { component: Component, element } = props;
-  const { events, type, elements, ...rest } = element;
+  const { type, elements, ...rest } = element;
+
+  // See WrappedHorizontalLayoutRenderer for explanation
+  const [events] = React.useState(element.events);
 
   React.useEffect(() => {
     events.onLoad();


### PR DESCRIPTION
## Change Summary

Fixes #135 by introducing a state variable which debounces the call to `onload` events

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a changeset
- [x] PR includes documentation if necessary
- [x] PR updates the [rich-embed examples](https://github.com/mod-protocol/mod/blob/main/examples/nextjs-shadcn/src/app/embeds.tsx) if necessary
- [x] includes a parallel PR for [Mod-starter](https://github.com/mod-protocol/mod-starter) and the gateway if necessary
