### PR TITLE
fix(react-editor): inconsistent textcut detection

### DIFF
--- a/.changeset/empty-bees-lick.md
+++ b/.changeset/empty-bees-lick.md
@@ -1,0 +1,5 @@
+---
+"@mod-protocol/tiptap-extension-link": patch
+---
+
+fix: inconsistent textcut detection

--- a/packages/react-editor/package.json
+++ b/packages/react-editor/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "eslint \"**/*.ts*\" && tsc --noEmit",
     "build": "tsup src/index.tsx --format cjs,esm --dts",
-    "dev": "npm run build -- --watch"
+    "dev": "npm run build -- --watch . --watch ../tiptap-extension-channel-mention --watch ../tiptap-extension-link"
   },
   "dependencies": {
     "@tiptap/core": "^2.0.4",

--- a/packages/tiptap-extension-link/src/helpers/textcuts.ts
+++ b/packages/tiptap-extension-link/src/helpers/textcuts.ts
@@ -2,7 +2,7 @@ import { MultiToken, Options, tokenize } from "linkifyjs";
 import { LinkifyLink } from "../link";
 
 const textcuts =
-  /(\b)([^ \.\n,]+)(\.)(twitter|github|lens|telegram|eth)($| |\n)/gi;
+  /(\b)([^ \.\n,]+)(\.)(twitter|github|lens|telegram|eth)($| |\n)/i;
 
 function isTokenTextcut(str: MultiToken): boolean {
   return textcuts.test(str.toString());


### PR DESCRIPTION
## Change Summary

Removes the global flag (`/g`) in the regex used by the `isTokenTextcut` function which made the regex stateful and resulted in unexpected behaviour when called consecutively.

Fixes #34

<img width="553" alt="Screenshot 2024-01-04 at 13 09 34" src="https://github.com/mod-protocol/mod/assets/5469870/4e5c4fec-2ccf-4cef-896f-dc64cd426539">

Also adds tiptap extension packages to tsup's `--watch` flags in the react-editor package's build command to automatically rebuild when changes are detected in those packages.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a changeset
- [x] PR includes documentation if necessary
- [x] PR updates the [rich-embed examples](https://github.com/mod-protocol/mod/blob/main/examples/nextjs-shadcn/src/app/embeds.tsx) if necessary
- [x] includes a parallel PR for [Mod-starter](https://github.com/mod-protocol/mod-starter) and the gateway if necessary
