### PR TITLE
fix(indexer): handle insertion error when cast has no url embeds

### DIFF
--- a/.changeset/real-dogs-end.md
+++ b/.changeset/real-dogs-end.md
@@ -1,0 +1,5 @@
+---
+"metadata-indexer": patch
+---
+
+fix: handle insertion error when cast has no url embeds

--- a/examples/metadata-indexer/src/indexerQueue.ts
+++ b/examples/metadata-indexer/src/indexerQueue.ts
@@ -94,11 +94,6 @@ export class IndexerQueue {
       this.log.error(
         `[URL Indexer] Response not ok [${response.status}] ${queryUrl}`
       );
-      if (response.status === 400 && retries === 0) {
-        // Retry 400 errors
-        this.log.info(`[URL Indexer] Queueing retry for ${url}...`);
-        this.indexQueue.push({ url, retries: retries + 1 });
-      }
       return;
     }
 


### PR DESCRIPTION
## Change Summary

Fixes an issue that would cause the indexer to crash due to invalid SQL generated when a cast only has cast embeds. The patch checks if there are rows to insert before building and executing the db query.

This patch also removes the logic which retries fetching a url if the status code is 400 because it generates HTTP 429 errors when restarting the indexer. Will monitor if this affects indexing coverage.

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a changeset
- [x] PR includes documentation if necessary
- [x] PR updates the [rich-embed examples](https://github.com/mod-protocol/mod/blob/main/examples/nextjs-shadcn/src/app/embeds.tsx) if necessary
- [x] includes a parallel PR for [Mod-starter](https://github.com/mod-protocol/mod-starter) and the gateway if necessary
