### PR TITLE
Revert "fix(react): debounce onload events"

### DIFF
--- a/.changeset/serious-dogs-sleep.md
+++ b/.changeset/serious-dogs-sleep.md
@@ -1,0 +1,5 @@
+---
+"@mod-protocol/react": patch
+---
+
+fix: revert #137 (debounce onload events)

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -175,12 +175,7 @@ const WrappedHorizontalLayoutRenderer = <T extends React.ReactNode>(props: {
   element: Extract<ModElementRef<T>, { type: "horizontal-layout" }>;
 }) => {
   const { component: Component, element } = props;
-  const { type, elements, ...rest } = element;
-
-  // Prevents the onLoad event from being called multiple times when
-  // the tree changes and reference to the events object changes.
-  // Assumes events are immutable over the lifecycle of a component
-  const [events] = React.useState(element.events);
+  const { events, type, elements, ...rest } = element;
 
   React.useEffect(() => {
     events.onLoad();
@@ -194,10 +189,7 @@ const WrappedVerticalLayoutRenderer = <T extends React.ReactNode>(props: {
   element: Extract<ModElementRef<T>, { type: "vertical-layout" }>;
 }) => {
   const { component: Component, element } = props;
-  const { type, elements, ...rest } = element;
-
-  // See WrappedHorizontalLayoutRenderer for explanation
-  const [events] = React.useState(element.events);
+  const { events, type, elements, ...rest } = element;
 
   React.useEffect(() => {
     events.onLoad();


### PR DESCRIPTION
This reverts commit 00993e04fb07f294c05d3b60e05d640ee4abd0ac.

## Change Summary

#137 breaks mods with onload in nested vertical/horizontal layout components (e.g. imgur/ipfs upload). Need to find a different solution

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a changeset
- [x] PR includes documentation if necessary
- [x] PR updates the [rich-embed examples](https://github.com/mod-protocol/mod/blob/main/examples/nextjs-shadcn/src/app/embeds.tsx) if necessary
- [x] includes a parallel PR for [Mod-starter](https://github.com/mod-protocol/mod-starter) and the gateway if necessary
