### PR TITLE
fix(core): onload events

### DIFF
--- a/.changeset/smooth-feet-grow.md
+++ b/.changeset/smooth-feet-grow.md
@@ -1,0 +1,6 @@
+---
+"@mod-protocol/react": patch
+"@mod-protocol/core": patch
+---
+
+fix: onload events

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1099,7 +1099,15 @@ export class Renderer {
       el: ModElement | ConditionalFlow<ModElement>,
       index: number
     ): T | null => {
-      const key = index + "";
+      let key = index + "";
+
+      if ("onload" in el) {
+        if (typeof el.onload === "string") {
+          key += `-${el.onload}`;
+        } else if (typeof el.onload === "object" && "ref" in el.onload) {
+          key += `-${el.onload.ref}`;
+        }
+      }
 
       if ("if" in el) {
         const { if: if_, then: then_, else: else_ } = el;

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -175,7 +175,8 @@ const WrappedHorizontalLayoutRenderer = <T extends React.ReactNode>(props: {
   element: Extract<ModElementRef<T>, { type: "horizontal-layout" }>;
 }) => {
   const { component: Component, element } = props;
-  const { events, type, elements, ...rest } = element;
+  const { type, elements, ...rest } = element;
+  const [events] = React.useState(element.events);
 
   React.useEffect(() => {
     events.onLoad();
@@ -189,7 +190,8 @@ const WrappedVerticalLayoutRenderer = <T extends React.ReactNode>(props: {
   element: Extract<ModElementRef<T>, { type: "vertical-layout" }>;
 }) => {
   const { component: Component, element } = props;
-  const { events, type, elements, ...rest } = element;
+  const { type, elements, ...rest } = element;
+  const [events] = React.useState(element.events);
 
   React.useEffect(() => {
     events.onLoad();


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->

- Fixes #135 by debouncing the onload event call
- Creates unique keys for components with a `ref` key to ensure changes in the component tree are not missed at render time

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a changeset
- [x] PR includes documentation if necessary
- [x] PR updates the [rich-embed examples](https://github.com/mod-protocol/mod/blob/main/examples/nextjs-shadcn/src/app/embeds.tsx) if necessary
- [x] includes a parallel PR for [Mod-starter](https://github.com/mod-protocol/mod-starter) and the gateway if necessary
