### PR TITLE
feat: mod/client referrals

### DIFF
--- a/.changeset/late-timers-hammer.md
+++ b/.changeset/late-timers-hammer.md
@@ -1,0 +1,6 @@
+---
+"@mod-protocol/react": minor
+"@mod-protocol/core": minor
+---
+
+feat: client and mod attribution in transactions

--- a/.changeset/slow-goats-share.md
+++ b/.changeset/slow-goats-share.md
@@ -1,0 +1,18 @@
+---
+"@mods/infura-ipfs-upload": patch
+"@mods/chatgpt-shorten": patch
+"@mods/zora-nft-minter": patch
+"@mods/livepeer-video": patch
+"@mods/giphy-picker": patch
+"@mods/image-render": patch
+"@mods/imgur-upload": patch
+"@mods/video-render": patch
+"@mods/zora-create": patch
+"@mods/nft-minter": patch
+"@mods/url-render": patch
+"@mods/chatgpt": patch
+"@mods/dall-e": patch
+"@mod-protocol/core": minor
+---
+
+fix: deprecate ENS support for `ModManifest` `custodyAddress` field

--- a/mods/chatgpt-shorten/src/manifest.ts
+++ b/mods/chatgpt-shorten/src/manifest.ts
@@ -7,7 +7,7 @@ import loading from "./loading";
 const manifest: ModManifest = {
   slug: "chatgpt-shorten",
   name: "Shorten text using AI",
-  custodyAddress: "furlong.eth",
+  custodyAddress: "0xdcC59cF0Adf4175973D4abc8c0715f83f90d2f1d",
   logo: "https://i.imgur.com/hV566qC.png",
   custodyGithubUsername: "davidfurlong",
   version: "0.0.1",

--- a/mods/chatgpt/src/manifest.ts
+++ b/mods/chatgpt/src/manifest.ts
@@ -7,7 +7,7 @@ import loading from "./loading";
 const manifest: ModManifest = {
   slug: "chatgpt",
   name: "Prompt ChatGPT",
-  custodyAddress: "furlong.eth",
+  custodyAddress: "0xdcC59cF0Adf4175973D4abc8c0715f83f90d2f1d",
   logo: "https://i.imgur.com/YayIWi1.png",
   custodyGithubUsername: "davidfurlong",
   version: "0.0.1",

--- a/mods/dall-e/src/manifest.ts
+++ b/mods/dall-e/src/manifest.ts
@@ -7,7 +7,7 @@ import loading from "./loading";
 const manifest: ModManifest = {
   slug: "dall-e",
   name: "Use AI to make an image",
-  custodyAddress: "furlong.eth",
+  custodyAddress: "0xdcC59cF0Adf4175973D4abc8c0715f83f90d2f1d",
   logo: "https://i.imgur.com/zKiFDal.png",
   custodyGithubUsername: "davidfurlong",
   version: "0.0.1",

--- a/mods/giphy-picker/src/manifest.ts
+++ b/mods/giphy-picker/src/manifest.ts
@@ -7,7 +7,7 @@ import loading from "./loading";
 const manifest: ModManifest = {
   slug: "giphy-picker",
   name: "Add GIF/Sticker",
-  custodyAddress: "furlong.eth",
+  custodyAddress: "0xdcC59cF0Adf4175973D4abc8c0715f83f90d2f1d",
   custodyGithubUsername: "davidfurlong",
   logo: "https://i.imgur.com/vccxL2r.png",
   version: "0.0.1",

--- a/mods/image-render/src/manifest.ts
+++ b/mods/image-render/src/manifest.ts
@@ -4,7 +4,7 @@ import view from "./view";
 const manifest: ModManifest = {
   slug: "image-render",
   name: "View Images",
-  custodyAddress: "furlong.eth",
+  custodyAddress: "0xdcC59cF0Adf4175973D4abc8c0715f83f90d2f1d",
   version: "0.0.1",
   logo: "https://i.imgur.com/75cFuT9.png",
   custodyGithubUsername: "davidfurlong",

--- a/mods/imgur-upload/src/manifest.ts
+++ b/mods/imgur-upload/src/manifest.ts
@@ -7,7 +7,7 @@ import upload from "./upload";
 const manifest: ModManifest = {
   slug: "imgur-upload",
   name: "Upload image to Imgur",
-  custodyAddress: "stephancill.eth",
+  custodyAddress: "0xdcC59cF0Adf4175973D4abc8c0715f83f90d2f1d",
   logo: "https://imgur.com/favicon.ico",
   custodyGithubUsername: "stephancill",
   version: "0.0.1",

--- a/mods/infura-ipfs-upload/src/manifest.ts
+++ b/mods/infura-ipfs-upload/src/manifest.ts
@@ -7,7 +7,7 @@ import upload from "./upload";
 const manifest: ModManifest = {
   slug: "infura-ipfs-upload",
   name: "Add image",
-  custodyAddress: "furlong.eth",
+  custodyAddress: "0xdcC59cF0Adf4175973D4abc8c0715f83f90d2f1d",
   logo: "https://i.imgur.com/FxgecX7.png",
   custodyGithubUsername: "davidfurlong",
   version: "0.0.1",

--- a/mods/livepeer-video/src/manifest.ts
+++ b/mods/livepeer-video/src/manifest.ts
@@ -7,7 +7,7 @@ import upload from "./upload";
 const manifest: ModManifest = {
   slug: "livepeer-video",
   name: "Add video",
-  custodyAddress: "furlong.eth",
+  custodyAddress: "0xdcC59cF0Adf4175973D4abc8c0715f83f90d2f1d",
   logo: "https://i.imgur.com/89epIn5.png",
   custodyGithubUsername: "davidfurlong",
   version: "0.0.1",

--- a/mods/nft-minter/src/manifest.ts
+++ b/mods/nft-minter/src/manifest.ts
@@ -4,7 +4,7 @@ import view from "./view";
 const manifest: ModManifest = {
   slug: "nft-minter",
   name: "Preview and mint NFTs",
-  custodyAddress: "furlong.eth",
+  custodyAddress: "0xdcC59cF0Adf4175973D4abc8c0715f83f90d2f1d",
   version: "0.0.1",
   logo: "https://i.imgur.com/fuSkgoJ.png",
   custodyGithubUsername: "davidfurlong",

--- a/mods/url-render/src/manifest.ts
+++ b/mods/url-render/src/manifest.ts
@@ -5,7 +5,7 @@ import fullimage from "./fullimage";
 const manifest: ModManifest = {
   slug: "url-render",
   name: "View urls",
-  custodyAddress: "furlong.eth",
+  custodyAddress: "0xdcC59cF0Adf4175973D4abc8c0715f83f90d2f1d",
   version: "0.0.1",
   logo: "https://i.imgur.com/E7PAMHH.png",
   custodyGithubUsername: "davidfurlong",

--- a/mods/video-render/src/manifest.ts
+++ b/mods/video-render/src/manifest.ts
@@ -4,7 +4,7 @@ import view from "./view";
 const manifest: ModManifest = {
   slug: "video-render",
   name: "View Videos",
-  custodyAddress: "furlong.eth",
+  custodyAddress: "0xdcC59cF0Adf4175973D4abc8c0715f83f90d2f1d",
   version: "0.0.1",
   logo: "https://i.imgur.com/RITeKTW.png",
   custodyGithubUsername: "davidfurlong",

--- a/mods/zora-create/src/manifest.ts
+++ b/mods/zora-create/src/manifest.ts
@@ -6,7 +6,7 @@ import loading from "./loading";
 const manifest: ModManifest = {
   slug: "zora-create",
   name: "Add NFT via Zora Premint",
-  custodyAddress: "stephancill.eth",
+  custodyAddress: "0xdcC59cF0Adf4175973D4abc8c0715f83f90d2f1d",
   logo: "https://i.imgur.com/rsfLOfD.png",
   custodyGithubUsername: "stephancill",
   version: "0.0.1",

--- a/mods/zora-nft-minter/src/manifest.ts
+++ b/mods/zora-nft-minter/src/manifest.ts
@@ -4,7 +4,7 @@ import view from "./view";
 const manifest: ModManifest = {
   slug: "zora-nft-minter",
   name: "Preview and mint Zora NFTs",
-  custodyAddress: "stephancill.eth",
+  custodyAddress: "0xdcC59cF0Adf4175973D4abc8c0715f83f90d2f1d",
   version: "0.0.1",
   logo: "https://i.imgur.com/fuSkgoJ.png",
   custodyGithubUsername: "stephancill",

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -12,8 +12,8 @@ export type ModManifest = {
   name: string;
   /** A (temporary) github username to define as the owner */
   custodyGithubUsername: string;
-  /** An ethereum address or ENS address to define as the owner */
-  custodyAddress: string;
+  /** An ethereum address to define as the owner */
+  custodyAddress: `0x${string}`;
   /** A valid url pointing to an image file, it should be a square */
   logo: string;
   /** should be the same as the package version */

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -453,8 +453,14 @@ export const CreationMod = (
 
   const input = variant === "creation" ? props.input : "";
   const context = React.useMemo<CreationContext>(
-    () => ({ input, embeds: props.embeds, api: props.api, user: props.user }),
-    [input, props.api, props.embeds, props.user]
+    () => ({
+      input,
+      embeds: props.embeds,
+      api: props.api,
+      user: props.user,
+      clientReferralAddress: props.clientReferralAddress,
+    }),
+    [input, props.api, props.embeds, props.user, props.clientReferralAddress]
   );
 
   const [renderer] = React.useState<Renderer>(
@@ -501,8 +507,13 @@ export const RenderMod = (
   const forceRerender = useForceRerender();
 
   const context = React.useMemo<RichEmbedContext>(
-    () => ({ embed: props.embed, api: props.api, user: props.user }),
-    [props.embed, props.api, props.user]
+    () => ({
+      embed: props.embed,
+      api: props.api,
+      user: props.user,
+      clientReferralAddress: props.clientReferralAddress,
+    }),
+    [props.embed, props.api, props.user, props.clientReferralAddress]
   );
 
   const [renderer] = React.useState<Renderer>(


### PR DESCRIPTION
## Change Summary

- Deprecate ENS support in `ModManifest`'s `custodyAddress` field
- Append Mod custody address and client referral address to transactions created via Mod to allow for fee revenue sharing

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a changeset
- [ ] PR includes documentation if necessary
- [ ] PR updates the [rich-embed examples](https://github.com/mod-protocol/mod/blob/main/examples/nextjs-shadcn/src/app/embeds.tsx) if necessary
- [ ] includes a parallel PR for [Mod-starter](https://github.com/mod-protocol/mod-starter) and the gateway if necessary
