### PR TITLE
Feat: Support Farcaster frames in the metadata indexer + og endpoint

### DIFF
--- a/.changeset/fresh-geese-sing.md
+++ b/.changeset/fresh-geese-sing.md
@@ -1,0 +1,6 @@
+---
+"@mod-protocol/core": patch
+"api": patch
+---
+
+add farcaster frames indexing

--- a/docs/pages/metadata-cache.mdx
+++ b/docs/pages/metadata-cache.mdx
@@ -187,6 +187,14 @@ type UrlMetadata = {
     logo?: {
         url: string;
     };
+    customOpenGraph?: {
+      "fc:frame"?: string;
+      "fc:frame:image"?: string;
+      "fc:frame:button:1"?: string;
+      "fc:frame:button:2"?: string;
+      "fc:frame:button:3"?: string;
+      "fc:frame:button:4"?: string;
+    };
     nft?: {
       owner?: FarcasterUser;
       tokenId?: string;

--- a/examples/api/src/app/api/open-graph/lib/url-handlers/local-fetch.ts
+++ b/examples/api/src/app/api/open-graph/lib/url-handlers/local-fetch.ts
@@ -64,9 +64,40 @@ async function localFetchHandler(url: string): Promise<UrlMetadata> {
         property: "eth:nft:mint_url",
         fieldName: "ethNftMintUrl",
       },
+      {
+        multiple: false,
+        property: "fc:frame",
+        fieldName: "fcFrame",
+      },
+      {
+        multiple: false,
+        property: "fc:frame:image",
+        fieldName: "fcFrameImage",
+      },
+      {
+        multiple: false,
+        property: "fc:frame:button:1",
+        fieldName: "fcFrameButton1",
+      },
+      {
+        multiple: false,
+        property: "fc:frame:button:2",
+        fieldName: "fcFrameButton2",
+      },
+      {
+        multiple: false,
+        property: "fc:frame:button:3",
+        fieldName: "fcFrameButton3",
+      },
+      {
+        multiple: false,
+        property: "fc:frame:button:4",
+        fieldName: "fcFrameButton4",
+      },
     ],
   });
 
+  /** Load any NFT metadata OG tags */
   let nftMetadata: NFTMetadata | undefined;
   if (
     data["customMetaTags"] &&
@@ -110,6 +141,16 @@ async function localFetchHandler(url: string): Promise<UrlMetadata> {
     logo: data.ogLogo
       ? {
           url: data.ogLogo,
+        }
+      : undefined,
+    customOpenGraph: data["customMetaTags"]?.["fcFrame"]
+      ? {
+          "fc:frame": data["customMetaTags"]["fcFrame"],
+          "fc:frame:image": data["customMetaTags"]["fcFrameImage"],
+          "fc:frame:button:1": data["customMetaTags"]["fcFrameButton1"],
+          "fc:frame:button:2": data["customMetaTags"]["fcFrameButton2"],
+          "fc:frame:button:3": data["customMetaTags"]["fcFrameButton3"],
+          "fc:frame:button:4": data["customMetaTags"]["fcFrameButton4"],
         }
       : undefined,
     "json-ld": groupLinkedDataByType(linkedData),

--- a/examples/api/src/app/api/open-graph/lib/url-handlers/metascraper.ts
+++ b/examples/api/src/app/api/open-graph/lib/url-handlers/metascraper.ts
@@ -22,6 +22,8 @@ const ethDataSelectors: {
   },
 ];
 
+// TODO: Support fc:frame here or remove endpoint https://warpcast.notion.site/Farcaster-Frames-4bd47fe97dc74a42a48d3a234636d8c5
+
 const jsonLdDataSelector = new URLSearchParams({
   "data.json-ld.selectorAll": 'script[type="application/ld+json"]',
   "data.json-ld.attr": "text",

--- a/examples/metadata-indexer/src/db.ts
+++ b/examples/metadata-indexer/src/db.ts
@@ -92,6 +92,7 @@ export type CastEmbedUrlRow = {
 export type UrlMetadataRow = {
   id: GeneratedAlways<string>;
   url: string;
+  customOpenGraph: object | null;
   createdAt: Generated<Date>;
   updatedAt: Date | null; // null means it hasn't been indexed yet
   imageUrl: string | null;

--- a/examples/metadata-indexer/src/indexerQueue.ts
+++ b/examples/metadata-indexer/src/indexerQueue.ts
@@ -127,6 +127,7 @@ export class IndexerQueue {
       .insertInto("urlMetadata")
       .values({
         url,
+        customOpenGraph: result.customOpenGraph ?? null,
         updatedAt: new Date(),
         imageUrl: result.image?.url,
         imageWidth: result.image?.width,

--- a/examples/metadata-indexer/src/migrations/002_customog.ts
+++ b/examples/metadata-indexer/src/migrations/002_customog.ts
@@ -1,0 +1,15 @@
+import { DB } from "../db";
+
+export const up = async (db: DB) => {
+  await db.schema
+    .alterTable("urlMetadata")
+    .addColumn("customOpenGraph", "jsonb")
+    .execute();
+};
+
+export const down = async (db: DB) => {
+  await db.schema
+    .alterTable("urlMetadata")
+    .dropColumn("customOpenGraph")
+    .execute();
+};

--- a/packages/core/src/embeds.ts
+++ b/packages/core/src/embeds.ts
@@ -63,6 +63,14 @@ export type UrlMetadata = {
   alt?: string;
   title?: string;
   publisher?: string;
+  customOpenGraph?: {
+    "fc:frame"?: string;
+    "fc:frame:image"?: string;
+    "fc:frame:button:1"?: string;
+    "fc:frame:button:2"?: string;
+    "fc:frame:button:3"?: string;
+    "fc:frame:button:4"?: string;
+  };
   logo?: {
     url: string;
   };


### PR DESCRIPTION
## Change Summary

Support Farcaster frames in the metadata indexer + og endpoint

https://warpcast.notion.site/Farcaster-Frames-4bd47fe97dc74a42a48d3a234636d8c5

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a changeset
- [x] PR includes documentation if necessary
- [x] PR updates the [rich-embed examples](https://github.com/mod-protocol/mod/blob/main/examples/nextjs-shadcn/src/app/embeds.tsx) if necessary
- [x] includes a parallel PR for [Mod-starter](https://github.com/mod-protocol/mod-starter) and the gateway if necessary
