### PR TITLE
feat(api): add custom opengraph to cast-embeds-metadata endpoint

### DIFF
--- a/.changeset/proud-pears-attend.md
+++ b/.changeset/proud-pears-attend.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+feat: add custom opengraph to cast-embeds-metadata endpoint

--- a/examples/api/src/app/api/cast-embeds-metadata/by-url/route.ts
+++ b/examples/api/src/app/api/cast-embeds-metadata/by-url/route.ts
@@ -41,6 +41,7 @@ export async function POST(request: NextRequest) {
         "url_metadata.mime_type as url_mime_type",
         "url_metadata.nft_collection_id as nft_collection_id",
         "url_metadata.nft_metadata_id as nft_metadata_id",
+        "url_metadata.custom_open_graph as url_custom_open_graph",
 
         // NFT Collection metadata
         "nft_collections.creator_address as collection_creator_address",
@@ -106,6 +107,9 @@ export async function POST(request: NextRequest) {
         logo: row.url_logo_url ? { url: row.url_logo_url } : undefined,
         mimeType: row.url_mime_type || undefined,
         nft: nftMetadata,
+        customOpenGraph: (row.url_custom_open_graph || undefined) as
+          | any
+          | undefined,
       };
 
       return {

--- a/examples/api/src/app/api/cast-embeds-metadata/route.ts
+++ b/examples/api/src/app/api/cast-embeds-metadata/route.ts
@@ -64,6 +64,7 @@ function formatRow(row): EmbedWithCastHash {
       logo: row.url_logo_url ? { url: row.url_logo_url } : undefined,
       mimeType: row.url_mime_type || undefined,
       nft: nftMetadata,
+      customOpenGraph: row.url_custom_open_graph || undefined,
     };
   }
 
@@ -124,6 +125,7 @@ export async function POST(request: NextRequest) {
         "url_metadata.mime_type as url_mime_type",
         "url_metadata.nft_collection_id as nft_collection_id",
         "url_metadata.nft_metadata_id as nft_metadata_id",
+        "url_metadata.custom_open_graph as url_custom_open_graph",
 
         // NFT Collection metadata
         "nft_collections.creator_address as collection_creator_address",

--- a/examples/api/src/app/api/cast-embeds-metadata/types/db.d.ts
+++ b/examples/api/src/app/api/cast-embeds-metadata/types/db.d.ts
@@ -6,6 +6,18 @@ export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
 
 export type Int8 = ColumnType<string, bigint | number | string, bigint | number | string>;
 
+export type Json = ColumnType<JsonValue, string, string>;
+
+export type JsonArray = JsonValue[];
+
+export type JsonObject = {
+  [K in string]?: JsonValue;
+};
+
+export type JsonPrimitive = boolean | number | string | null;
+
+export type JsonValue = JsonArray | JsonObject | JsonPrimitive;
+
 export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
 export interface CastEmbedUrls {
@@ -59,6 +71,7 @@ export interface NftMetadata {
 export interface UrlMetadata {
   alt: string | null;
   created_at: Generated<Timestamp>;
+  custom_open_graph: Json | null;
   description: string | null;
   image_height: number | null;
   image_url: string | null;


### PR DESCRIPTION
## Change Summary

Adds custom opengraph data to cast-embeds-metadata endpoints

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a changeset
- [x] PR includes documentation if necessary
- [x] PR updates the [rich-embed examples](https://github.com/mod-protocol/mod/blob/main/examples/nextjs-shadcn/src/app/embeds.tsx) if necessary
- [x] includes a parallel PR for [Mod-starter](https://github.com/mod-protocol/mod-starter) and the gateway if necessary
