### PR TITLE
fix(indexer): ignore NaN values for image dimensions

### DIFF
--- a/.changeset/funny-jeans-deny.md
+++ b/.changeset/funny-jeans-deny.md
@@ -1,0 +1,5 @@
+---
+"metadata-indexer": patch
+---
+
+fix: ignore NaN values for image dimensions

--- a/examples/metadata-indexer/src/indexerQueue.ts
+++ b/examples/metadata-indexer/src/indexerQueue.ts
@@ -157,10 +157,14 @@ export class IndexerQueue {
       customOpenGraph: result.customOpenGraph || null,
       updatedAt: new Date(),
       imageUrl: result.image?.url || null,
-      imageWidth: result.image?.width ? Math.floor(result.image.width) : null,
-      imageHeight: result.image?.height
-        ? Math.floor(result.image.height)
-        : null,
+      imageWidth:
+        result.image?.width && Math.floor(result.image.width)
+          ? Math.floor(result.image.width)
+          : null,
+      imageHeight:
+        result.image?.height && Math.floor(result.image.height)
+          ? Math.floor(result.image.height)
+          : null,
       description: result.description || null,
       alt: result.alt || null,
       title: result.title || null,


### PR DESCRIPTION
## Change Summary

<!--- Describe the changes in 1-2 concise sentences. -->

Ignore NaN values for image dimensions when inserting url metadata

## Merge Checklist

<!-- Check the completed and unnecessary tasks below -->

- [x] PR has a changeset
- [x] PR includes documentation if necessary
- [x] PR updates the [rich-embed examples](https://github.com/mod-protocol/mod/blob/main/examples/nextjs-shadcn/src/app/embeds.tsx) if necessary
- [x] includes a parallel PR for [Mod-starter](https://github.com/mod-protocol/mod-starter) and the gateway if necessary
